### PR TITLE
Enable PDL for FlashKDA kernels

### DIFF
--- a/csrc/smxx/fwd_kernel1.cuh
+++ b/csrc/smxx/fwd_kernel1.cuh
@@ -118,6 +118,10 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     float const* A_log_ptr,
     float gate_scale
 ) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+    cudaGridDependencySynchronize();
+#endif
+
     // --- constants
     using BF16 = cutlass::bfloat16_t;
     using FP16 = cutlass::half_t;
@@ -179,7 +183,12 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     seq_len = int(eos - bos);
     t_tiles_this_seq = (seq_len + CHUNK - 1) / CHUNK;
     // Early exit for excess CTAs (total_tiles is an upper bound)
-    if (local_t >= t_tiles_this_seq) return;
+    if (local_t >= t_tiles_this_seq) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+        cudaTriggerProgrammaticLaunchCompletion();
+#endif
+        return;
+    }
     // --- TMA load inputs (single-shot, no pipeline)
     // Only thread 0 issues TMA loads (not elect_one_sync which is per-warp)
     if (threadIdx.x == 0) {
@@ -568,4 +577,7 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     }
     tma_store_wait<0>();
     __syncthreads();
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
 }

--- a/csrc/smxx/fwd_kernel1.cuh
+++ b/csrc/smxx/fwd_kernel1.cuh
@@ -118,8 +118,6 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     float const* A_log_ptr,
     float gate_scale
 ) {
-    cudaGridDependencySynchronize();
-
     // --- constants
     using BF16 = cutlass::bfloat16_t;
     using FP16 = cutlass::half_t;
@@ -145,6 +143,14 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     extern __shared__ __align__(128) unsigned char shared_mem[];
     using SharedStorageT = SharedStorageK1<Layouts>;
     SharedStorageT& shared_storage = *reinterpret_cast<SharedStorageT*>(shared_mem);
+    int warp_id = cutlass::canonical_warp_idx_sync();
+
+    if (warp_id == 0 && cute::elect_one_sync()) {
+        shared_storage.tma_load_barrier.init(1);
+        cutlass::arch::fence_barrier_init();
+    }
+    __syncthreads();
+    cudaGridDependencySynchronize();
 
     // --- per-CTA tile info
     int global_tile_idx = blockIdx.x;
@@ -186,11 +192,8 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
         return;
     }
     // --- TMA load inputs (single-shot, no pipeline)
-    // Only thread 0 issues TMA loads (not elect_one_sync which is per-warp)
-    if (threadIdx.x == 0) {
+    if (warp_id == 0) {
         using BarrierType = cutlass::arch::ClusterTransactionBarrier::ValueType;
-        shared_storage.tma_load_barrier.init(1);
-        shared_storage.tma_load_barrier.arrive_and_expect_tx(kTmaTransactionBytes);
 
         Tensor g_q = tma_load_q.get_tma_tensor(make_shape(H, T_total, D));
         Tensor g_k = tma_load_k.get_tma_tensor(make_shape(H, T_total, D));
@@ -215,21 +218,11 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
         Tensor s_k_tile = make_tensor(make_smem_ptr(shared_storage.k.begin()), TMAQKLayout{});
         Tensor s_beta_tile = make_tensor(make_smem_ptr(shared_storage.beta.begin()), TMABetaSmemLayout{});
 
-        cute::copy(tma_load_q.with(reinterpret_cast<BarrierType&>(shared_storage.tma_load_barrier)),
-            cta_tma_load_q.partition_S(g_q_tile), cta_tma_load_q.partition_D(s_q_tile));
-        cute::copy(tma_load_k.with(reinterpret_cast<BarrierType&>(shared_storage.tma_load_barrier)),
-            cta_tma_load_k.partition_S(g_k_tile), cta_tma_load_k.partition_D(s_k_tile));
-        cute::copy(tma_load_beta.with(reinterpret_cast<BarrierType&>(shared_storage.tma_load_barrier)),
-            cta_tma_load_beta.partition_S(g_beta_tile), cta_tma_load_beta.partition_D(s_beta_tile));
-
         // TMA load g_bf16 (same gmem layout as q/k)
         Tensor g_g = tma_load_g.get_tma_tensor(make_shape(H, T_total, D));
         auto cta_tma_load_g = tma_load_g.get_slice(Int<0>{});
         Tensor g_g_tile = make_tensor(g_g.data() + qk_off, make_layout(tile_shape_3d, tile_stride_3d));
         Tensor s_g_bf16_tile = make_tensor(make_smem_ptr(shared_storage.g_bf16.begin()), TMAQKLayout{});
-        cute::copy(tma_load_g.with(reinterpret_cast<BarrierType&>(shared_storage.tma_load_barrier)),
-            cta_tma_load_g.partition_S(g_g_tile), cta_tma_load_g.partition_D(s_g_bf16_tile));
-
         // TMA load dt_bias [H, D] → [D] slice for current head
         Tensor g_dt = tma_load_dt_bias.get_tma_tensor(make_shape(H, D));
         auto cta_tma_load_dt = tma_load_dt_bias.get_slice(Int<0>{});
@@ -237,15 +230,25 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
         Tensor g_dt_tile = make_tensor(g_dt.data() + dt_off,
             make_layout(make_shape(Int<1>{}, Int<D>{}), stride(g_dt.layout())));
         Tensor s_dt_tile = make_tensor(make_smem_ptr(shared_storage.dt_bias.begin()), TMAGTotalSmemLayout{});
-        cute::copy(tma_load_dt_bias.with(reinterpret_cast<BarrierType&>(shared_storage.tma_load_barrier)),
-            cta_tma_load_dt.partition_S(g_dt_tile), cta_tma_load_dt.partition_D(s_dt_tile));
+        if (cute::elect_one_sync()) {
+            shared_storage.tma_load_barrier.arrive_and_expect_tx(kTmaTransactionBytes);
+            cute::copy(tma_load_q.with(reinterpret_cast<BarrierType&>(shared_storage.tma_load_barrier)),
+                cta_tma_load_q.partition_S(g_q_tile), cta_tma_load_q.partition_D(s_q_tile));
+            cute::copy(tma_load_k.with(reinterpret_cast<BarrierType&>(shared_storage.tma_load_barrier)),
+                cta_tma_load_k.partition_S(g_k_tile), cta_tma_load_k.partition_D(s_k_tile));
+            cute::copy(tma_load_beta.with(reinterpret_cast<BarrierType&>(shared_storage.tma_load_barrier)),
+                cta_tma_load_beta.partition_S(g_beta_tile), cta_tma_load_beta.partition_D(s_beta_tile));
+            cute::copy(tma_load_g.with(reinterpret_cast<BarrierType&>(shared_storage.tma_load_barrier)),
+                cta_tma_load_g.partition_S(g_g_tile), cta_tma_load_g.partition_D(s_g_bf16_tile));
+            cute::copy(tma_load_dt_bias.with(reinterpret_cast<BarrierType&>(shared_storage.tma_load_barrier)),
+                cta_tma_load_dt.partition_S(g_dt_tile), cta_tma_load_dt.partition_D(s_dt_tile));
+        }
+        // --- Wait for TMA (q, k, beta, g_bf16, dt_bias)
+        shared_storage.tma_load_barrier.wait(0);
     }
 
     // --- Compute a_log_exp (overlaps with TMA)
     float a_log_exp = expf(A_log_ptr[head_idx]);
-    // --- Wait for TMA (q, k, beta, g_bf16, dt_bias)
-    __syncthreads();
-    shared_storage.tma_load_barrier.wait(0);
     cutlass::arch::fence_view_async_shared();
     __syncthreads();
 
@@ -502,7 +505,10 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     // Fence + sync combined: completion + TMA visibility
     cutlass::arch::fence_view_async_shared();
     __syncthreads();
-    if (threadIdx.x == 0) {
+
+    cudaTriggerProgrammaticLaunchCompletion();
+
+    if (warp_id == 0) {
         int ws_idx = head_idx * total_tiles + global_tile_idx;
         // Store k_decayed [CHUNK, D] bf16
         {
@@ -512,8 +518,10 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
                 make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws.layout())));
             Tensor s_kd = make_tensor(make_smem_ptr(shared_storage.k_decayed.begin()), TMAVOLayout{});
             auto cta_tma = tma_store_ws_kd.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_kd, cta_tma.partition_S(s_kd), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
+            if (cute::elect_one_sync()) {
+                cute::copy(tma_store_ws_kd, cta_tma.partition_S(s_kd), cta_tma.partition_D(g_ws_tile));
+                tma_store_arrive();
+            }
         }
         // Store q_decayed
         {
@@ -523,8 +531,10 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
                 make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws.layout())));
             Tensor s_qd = make_tensor(make_smem_ptr(shared_storage.q_decayed.begin()), TMAVOLayout{});
             auto cta_tma = tma_store_ws_qd.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_qd, cta_tma.partition_S(s_qd), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
+            if (cute::elect_one_sync()) {
+                cute::copy(tma_store_ws_qd, cta_tma.partition_S(s_qd), cta_tma.partition_D(g_ws_tile));
+                tma_store_arrive();
+            }
         }
         // Store k_restored
         {
@@ -534,8 +544,10 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
                 make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws.layout())));
             Tensor s_kr = make_tensor(make_smem_ptr(shared_storage.k_restored.begin()), TMAVOLayout{});
             auto cta_tma = tma_store_ws_kr.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_kr, cta_tma.partition_S(s_kr), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
+            if (cute::elect_one_sync()) {
+                cute::copy(tma_store_ws_kr, cta_tma.partition_S(s_kr), cta_tma.partition_D(g_ws_tile));
+                tma_store_arrive();
+            }
         }
         // Store g_total [D] float
         {
@@ -545,8 +557,10 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
                 make_layout(make_shape(Int<1>{}, Int<D>{}), stride(g_ws.layout())));
             Tensor s_gt = make_tensor(make_smem_ptr(shared_storage.g_total.begin()), TMAGTotalSmemLayout{});
             auto cta_tma = tma_store_ws_gt.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_gt, cta_tma.partition_S(s_gt), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
+            if (cute::elect_one_sync()) {
+                cute::copy(tma_store_ws_gt, cta_tma.partition_S(s_gt), cta_tma.partition_D(g_ws_tile));
+                tma_store_arrive();
+            }
         }
         // Store INV [CHUNK, CHUNK] bf16
         {
@@ -556,8 +570,10 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
                 make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<CHUNK>{}), stride(g_ws.layout())));
             Tensor s_inv = make_tensor(make_smem_ptr(shared_storage.INV.begin()), TMALMLayout{});
             auto cta_tma = tma_store_ws_inv.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_inv, cta_tma.partition_S(s_inv), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
+            if (cute::elect_one_sync()) {
+                cute::copy(tma_store_ws_inv, cta_tma.partition_S(s_inv), cta_tma.partition_D(g_ws_tile));
+                tma_store_arrive();
+            }
         }
         // Store Mqk [CHUNK, CHUNK] bf16
         {
@@ -567,11 +583,10 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
                 make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<CHUNK>{}), stride(g_ws.layout())));
             Tensor s_mqk = make_tensor(make_smem_ptr(shared_storage.Mqk.begin()), TMALMLayout{});
             auto cta_tma = tma_store_ws_mqk.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_mqk, cta_tma.partition_S(s_mqk), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
+            if (cute::elect_one_sync()) {
+                cute::copy(tma_store_ws_mqk, cta_tma.partition_S(s_mqk), cta_tma.partition_D(g_ws_tile));
+                tma_store_arrive();
+            }
         }
     }
-    cudaTriggerProgrammaticLaunchCompletion();
-    tma_store_wait<0>();
-    __syncthreads();
 }

--- a/csrc/smxx/fwd_kernel1.cuh
+++ b/csrc/smxx/fwd_kernel1.cuh
@@ -118,9 +118,7 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     float const* A_log_ptr,
     float gate_scale
 ) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
     cudaGridDependencySynchronize();
-#endif
 
     // --- constants
     using BF16 = cutlass::bfloat16_t;
@@ -184,9 +182,7 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     t_tiles_this_seq = (seq_len + CHUNK - 1) / CHUNK;
     // Early exit for excess CTAs (total_tiles is an upper bound)
     if (local_t >= t_tiles_this_seq) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
         cudaTriggerProgrammaticLaunchCompletion();
-#endif
         return;
     }
     // --- TMA load inputs (single-shot, no pipeline)
@@ -575,9 +571,7 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
             tma_store_arrive();
         }
     }
+    cudaTriggerProgrammaticLaunchCompletion();
     tma_store_wait<0>();
     __syncthreads();
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
-    cudaTriggerProgrammaticLaunchCompletion();
-#endif
 }

--- a/csrc/smxx/fwd_kernel2.cuh
+++ b/csrc/smxx/fwd_kernel2.cuh
@@ -150,6 +150,10 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     SeqlenT const* cu_seqlens,
     int total_tiles
 ) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+    cudaGridDependencySynchronize();
+#endif
+
     using BF16 = cutlass::bfloat16_t;
     using FP16 = cutlass::half_t;
     using Layouts = K2Layouts<D, CHUNK>;
@@ -795,6 +799,7 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
                 cta_tma_store_state.partition_D(g_final_tile)
             );
             tma_store_arrive();
+            tma_store_wait<0>();
         }
     }
 
@@ -827,9 +832,13 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
                 cta_tma_store_state.partition_D(g_final_tile)
             );
             tma_store_arrive();
+            tma_store_wait<0>();
         }
     }
 
     __syncthreads();
+#endif
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+    cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }

--- a/csrc/smxx/fwd_kernel2.cuh
+++ b/csrc/smxx/fwd_kernel2.cuh
@@ -150,9 +150,7 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     SeqlenT const* cu_seqlens,
     int total_tiles
 ) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
     cudaGridDependencySynchronize();
-#endif
 
     using BF16 = cutlass::bfloat16_t;
     using FP16 = cutlass::half_t;
@@ -799,7 +797,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
                 cta_tma_store_state.partition_D(g_final_tile)
             );
             tma_store_arrive();
-            tma_store_wait<0>();
         }
     }
 
@@ -832,13 +829,10 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
                 cta_tma_store_state.partition_D(g_final_tile)
             );
             tma_store_arrive();
-            tma_store_wait<0>();
         }
     }
 
     __syncthreads();
 #endif
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
     cudaTriggerProgrammaticLaunchCompletion();
-#endif
 }

--- a/csrc/smxx/fwd_kernel2.cuh
+++ b/csrc/smxx/fwd_kernel2.cuh
@@ -150,8 +150,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     SeqlenT const* cu_seqlens,
     int total_tiles
 ) {
-    cudaGridDependencySynchronize();
-
     using BF16 = cutlass::bfloat16_t;
     using FP16 = cutlass::half_t;
     using Layouts = K2Layouts<D, CHUNK>;
@@ -189,7 +187,8 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     SharedStorageT& shared_storage = *reinterpret_cast<SharedStorageT*>(shared_mem);
 
     // --- warp specialization
-    int warp_id = threadIdx.x / kWarpSize;
+    int warp_id = cutlass::canonical_warp_idx_sync();
+    bool lane_predicate = cute::elect_one_sync();
     WarpRole warp_role = WarpRole::NonParticipant;
     if (warp_id < kComputeThreads / kWarpSize) {
         warp_role = WarpRole::MMA;
@@ -200,6 +199,13 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     }
 
 #ifndef TMA_DISABLE_ALL
+    if constexpr (HasStateIn) {
+        if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
+            shared_storage.state_acc_tma_barrier.init(1);
+            cutlass::arch::fence_barrier_init();
+        }
+    }
+
     using LoadPipelineState = cutlass::PipelineState<InputStages>;
     using LoadPipeline = cutlass::PipelineTmaAsync<InputStages>;
     LoadPipeline load_pipeline = make_load_pipeline<InputStages>(
@@ -213,6 +219,8 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
         shared_storage.store_pipeline,
         warp_role, kComputeThreads, 1
     );
+
+    cutlass::pipeline_init_wait(1);  // __syncthreads()
 #endif
 
     // --- per-block sequence info
@@ -220,6 +228,8 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     int head_idx = blockIdx.y;
     int64_t bos, eos;
     int tile_base;
+
+    cudaGridDependencySynchronize();
 
     if constexpr (IsVarlen) {
         bos = cu_seqlens[seq_idx];
@@ -237,18 +247,14 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     }
     int seq_len  = int(eos - bos);
     int t_tiles  = (seq_len + CHUNK - 1) / CHUNK;
-    bool lane_predicate = cute::elect_one_sync();
 
     // --- Load initial state
 #ifndef TMA_DISABLE_ALL
     if constexpr (HasStateIn && !StateFP32) {
         // BF16 state: TMA load directly into state_acc
-        if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
+        if (warp_role == WarpRole::LOAD_QKG) {
             using BarrierType = cutlass::arch::ClusterTransactionBarrier::ValueType;
             constexpr uint32_t kStateTransactionBytes = cute::cosize_v<StateSmemLayout> * sizeof(BF16);
-
-            shared_storage.state_acc_tma_barrier.init(1);
-            shared_storage.state_acc_tma_barrier.arrive_and_expect_tx(kStateTransactionBytes);
 
             Tensor g_init = tma_load_initial_state.get_tma_tensor(make_shape(N * H, D, D));
             auto init_off = g_init.layout()(seq_idx * H + head_idx, 0, 0);
@@ -257,26 +263,26 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             Tensor s_state = make_tensor(make_smem_ptr(shared_storage.state_acc.begin()), TMAStateSmemLayout{});
 
             auto cta_tma_load_state = tma_load_initial_state.get_slice(Int<0>{});
-            cute::copy(
-                tma_load_initial_state.with(reinterpret_cast<BarrierType&>(shared_storage.state_acc_tma_barrier)),
-                cta_tma_load_state.partition_S(g_init_tile),
-                cta_tma_load_state.partition_D(s_state)
-            );
+            if (cute::elect_one_sync()) {
+                shared_storage.state_acc_tma_barrier.arrive_and_expect_tx(kStateTransactionBytes);
+                cute::copy(
+                    tma_load_initial_state.with(reinterpret_cast<BarrierType&>(shared_storage.state_acc_tma_barrier)),
+                    cta_tma_load_state.partition_S(g_init_tile),
+                    cta_tma_load_state.partition_D(s_state)
+                );
+            }
+            shared_storage.state_acc_tma_barrier.wait(0);
         }
         __syncthreads();
-        shared_storage.state_acc_tma_barrier.wait(0);
         cutlass::arch::fence_view_async_shared();
     } else if constexpr (HasStateIn && StateFP32) {
         // FP32 state: TMA load fp32 into pipeline buffer, then convert to bf16 in state_acc
         using FP32StateSmemLayout = typename Layouts::FP32StateSmemLayout;
         using TMAFP32StateSmemLayout = typename Layouts::TMAFP32StateSmemLayout;
 
-        if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
+        if (warp_role == WarpRole::LOAD_QKG) {
             using BarrierType = cutlass::arch::ClusterTransactionBarrier::ValueType;
             constexpr uint32_t kFP32StateTransactionBytes = cute::cosize_v<StateSmemLayout> * sizeof(float);
-
-            shared_storage.state_acc_tma_barrier.init(1);
-            shared_storage.state_acc_tma_barrier.arrive_and_expect_tx(kFP32StateTransactionBytes);
 
             Tensor g_init = tma_load_initial_state.get_tma_tensor(make_shape(N * H, D, D));
             auto init_off = g_init.layout()(seq_idx * H + head_idx, 0, 0);
@@ -287,14 +293,17 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
                 TMAFP32StateSmemLayout{});
 
             auto cta_tma_load_state = tma_load_initial_state.get_slice(Int<0>{});
-            cute::copy(
-                tma_load_initial_state.with(reinterpret_cast<BarrierType&>(shared_storage.state_acc_tma_barrier)),
-                cta_tma_load_state.partition_S(g_init_tile),
-                cta_tma_load_state.partition_D(s_fp32)
-            );
+            if (cute::elect_one_sync()) {
+                shared_storage.state_acc_tma_barrier.arrive_and_expect_tx(kFP32StateTransactionBytes);
+                cute::copy(
+                    tma_load_initial_state.with(reinterpret_cast<BarrierType&>(shared_storage.state_acc_tma_barrier)),
+                    cta_tma_load_state.partition_S(g_init_tile),
+                    cta_tma_load_state.partition_D(s_fp32)
+                );
+            }
+            shared_storage.state_acc_tma_barrier.wait(0);
         }
         __syncthreads();
-        shared_storage.state_acc_tma_barrier.wait(0);
         cutlass::arch::fence_view_async_shared();
 
         // All threads: convert fp32 -> bf16 with layout transformation
@@ -317,7 +326,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
 #endif
 
 #ifndef TMA_DISABLE_ALL
-    __syncthreads();
 
     // --- LOAD warp: issue TMA loads for v, beta, and workspace intermediates
     if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
@@ -470,7 +478,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
                 Tile<_16,_16,_16>{}
             );
 
-            const int warp_id = compute_tid / 32;
             const int lane_id = compute_tid % 32;
             const int group_id = (lane_id / 4) % 8;
 
@@ -782,6 +789,8 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             ++out_read;
         }
 
+        cudaTriggerProgrammaticLaunchCompletion();
+
         if constexpr (HasStateOut && !StateFP32) {
             // BF16 state: TMA store directly from state_acc
             Tensor g_final = tma_store_final_state.get_tma_tensor(make_shape(N * H, D, D));
@@ -831,8 +840,5 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             tma_store_arrive();
         }
     }
-
-    __syncthreads();
 #endif
-    cudaTriggerProgrammaticLaunchCompletion();
 }

--- a/csrc/smxx/fwd_launch.cu
+++ b/csrc/smxx/fwd_launch.cu
@@ -168,7 +168,18 @@ void launch_fwd(
         dim3 grid_k1(total_tiles, H);
         dim3 block_k1(kK1Threads);
 
-        kernel1<<<grid_k1, block_k1, smem_size_k1, stream>>>(
+        cudaLaunchConfig_t config{};
+        config.gridDim = grid_k1;
+        config.blockDim = block_k1;
+        config.dynamicSmemBytes = smem_size_k1;
+        config.stream = stream;
+        cudaLaunchAttribute attrs[1];
+        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attrs[0].val.programmaticStreamSerializationAllowed = 1;
+        config.attrs = attrs;
+        config.numAttrs = 1;
+
+        cudaLaunchKernelEx(&config, kernel1,
             tma_load_q, tma_load_k, tma_load_beta,
             tma_load_g, tma_load_dt_bias,
             tma_store_ws_kd, tma_store_ws_qd, tma_store_ws_kr,
@@ -202,7 +213,18 @@ void launch_fwd(
         dim3 grid_k2(N, H);
         dim3 block_k2(kK2Threads);
 
-        kernel2<<<grid_k2, block_k2, smem_size_k2, stream>>>(
+        cudaLaunchConfig_t config{};
+        config.gridDim = grid_k2;
+        config.blockDim = block_k2;
+        config.dynamicSmemBytes = smem_size_k2;
+        config.stream = stream;
+        cudaLaunchAttribute attrs[1];
+        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attrs[0].val.programmaticStreamSerializationAllowed = 1;
+        config.attrs = attrs;
+        config.numAttrs = 1;
+
+        cudaLaunchKernelEx(&config, kernel2,
             tma_load_v, tma_load_beta2,
             tma_load_ws_kd, tma_load_ws_qd, tma_load_ws_kr,
             tma_load_ws_gt, tma_load_ws_inv, tma_load_ws_mqk,

--- a/csrc/smxx/utils.cuh
+++ b/csrc/smxx/utils.cuh
@@ -111,7 +111,6 @@ cutlass::PipelineTmaAsync<Stages> make_load_pipeline(
     params.num_producers = num_producers;
 
     Pipeline pipeline(storage, params, Shape<_1,_1>{});
-    cutlass::pipeline_init_wait(1);
     return pipeline;
 }
 
@@ -138,7 +137,6 @@ cutlass::PipelineAsync<Stages> make_store_pipeline(
     params.consumer_arv_count = num_consumers;
 
     Pipeline pipeline(storage, params);
-    cutlass::pipeline_init_wait(1);
     return pipeline;
 }
 


### PR DESCRIPTION
Assisted-by: Codex <noreply@openai.com>

Also restructured the code a bit for PDL overlap to be effective
- Kernel1: move mbarrier init into separate prologue, so that we can issue GDC wait after mbarrier init. Use elect sync instead of tid == 0
- Kernel2: similarly, move mbarrier init for initial state TMA into prologue

Though not the main purpose of this PR, the slightly restructured kernels are slightly faster

### Kernel1

H | Sequences × length | Dev | Current | Improvement
-- | -- | -- | -- | --
96 | 1×8192 | 263.969 µs | 257.729 µs | 2.36%
96 | 2×4096 | 266.369 µs | 260.096 µs | 2.35%
96 | 4×2048 | 271.553 µs | 264.449 µs | 2.62%
12 | 1×8192 | 42.463 µs | 41.536 µs | 2.18%
12 | 2×4096 | 42.816 µs | 41.359 µs | 3.40%
12 | 4×2048 | 43.328 µs | 42.128 µs | 2.77%

### Kernel2

H | Sequences × length | Dev | Current | Improvement
-- | -- | -- | -- | --
96 | 1×8192 | 742.947 µs | 676.529 µs | 8.94%
96 | 2×4096 | 530.178 µs | 503.538 µs | 5.02%
96 | 4×2048 | 458.370 µs | 429.762 µs | 6.24%
12 | 1×8192 | 733.010 µs | 669.602 µs | 8.65%
12 | 2×4096 | 376.354 µs | 343.521 µs | 8.72%
12 | 4×2048 | 197.729 µs | 180.576 µs | 8.68%
