### PR TITLE
Integrate Flash-FlashKDA

### DIFF
--- a/csrc/smxx/fwd_kernel1.cuh
+++ b/csrc/smxx/fwd_kernel1.cuh
@@ -26,17 +26,7 @@ struct K1Layouts {
 
     using TMABetaSmemLayout = BetaSmemLayout;  // 1D TMA, no dummy dim
     using TMAQKLayout = decltype(prepend(QKLayout{}));
-    using TMAVOLayout = decltype(composition(
-        MMALayout{}.layout_a(),
-        MMALayout{}.offset(),
-        prepend(MMALayout{}.layout_b())
-    ));
     using TMAGLayout = decltype(prepend(GLayout{}));
-    using TMALMLayout = decltype(composition(
-        LMLayout{}.layout_a(),
-        LMLayout{}.offset(),
-        prepend(LMLayout{}.layout_b())
-    ));
     using TMAGTotalSmemLayout = decltype(prepend(GTotalLayout{}));
 };
 
@@ -70,6 +60,10 @@ struct SharedStorageK1 {
     };
 
     alignas(128) cute::ArrayEngine<BF16, cute::cosize_v<BetaSmemLayout>> beta;
+    alignas(16) cute::ArrayEngine<float, 16> beta_act;
+    alignas(16) cute::ArrayEngine<float, 16> q_norm_inv;
+    alignas(16) cute::ArrayEngine<float, 16> k_norm_inv;
+    float a_log_exp;
 
     union {
         alignas(128) cute::ArrayEngine<BF16, cute::cosize_v<QKLayout>> g_bf16;      // TMA load target
@@ -89,8 +83,6 @@ template <
     class TmaLoadBeta,
     class TmaLoadG,
     class TmaLoadDtBias,
-    class TmaStoreWsKD, class TmaStoreWsQD, class TmaStoreWsKR,
-    class TmaStoreWsGT, class TmaStoreWsINV, class TmaStoreWsMqk,
     int CHUNK,
     int D,
     int NumThreads,
@@ -103,12 +95,6 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     CUTE_GRID_CONSTANT TmaLoadBeta const tma_load_beta,
     CUTE_GRID_CONSTANT TmaLoadG const tma_load_g,
     CUTE_GRID_CONSTANT TmaLoadDtBias const tma_load_dt_bias,
-    CUTE_GRID_CONSTANT TmaStoreWsKD const tma_store_ws_kd,
-    CUTE_GRID_CONSTANT TmaStoreWsQD const tma_store_ws_qd,
-    CUTE_GRID_CONSTANT TmaStoreWsKR const tma_store_ws_kr,
-    CUTE_GRID_CONSTANT TmaStoreWsGT const tma_store_ws_gt,
-    CUTE_GRID_CONSTANT TmaStoreWsINV const tma_store_ws_inv,
-    CUTE_GRID_CONSTANT TmaStoreWsMqk const tma_store_ws_mqk,
     float scale,
     int T_total,
     int H,
@@ -116,7 +102,13 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     SeqlenT const* cu_seqlens,
     int total_tiles,
     float const* A_log_ptr,
-    float gate_scale
+    float gate_scale,
+    cutlass::bfloat16_t* ws_kd,
+    cutlass::bfloat16_t* ws_qd,
+    cutlass::bfloat16_t* ws_kr,
+    float* ws_gt,
+    cutlass::bfloat16_t* ws_inv,
+    cutlass::bfloat16_t* ws_mqk
 ) {
     // --- constants
     using BF16 = cutlass::bfloat16_t;
@@ -131,9 +123,8 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     using TransposedLMLayout = typename Layouts::TransposedLMLayout;
     using TMAQKLayout = typename Layouts::TMAQKLayout;
     using TMABetaSmemLayout = typename Layouts::TMABetaSmemLayout;
-    using TMAVOLayout = typename Layouts::TMAVOLayout;
-    using TMALMLayout = typename Layouts::TMALMLayout;
     using TMAGTotalSmemLayout = typename Layouts::TMAGTotalSmemLayout;
+    static_assert(NumThreads == 128);
     constexpr uint32_t kTmaTransactionBytes =
         uint32_t(cute::cosize_v<QKLayout>) * uint32_t(3 * sizeof(BF16)) +  // q + k + g_bf16
         uint32_t(32) * uint32_t(sizeof(BF16)) +  // beta (bf16, sigmoid fused)
@@ -236,96 +227,93 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
             cta_tma_load_dt.partition_S(g_dt_tile), cta_tma_load_dt.partition_D(s_dt_tile));
     }
 
-    // --- Compute a_log_exp (overlaps with TMA)
-    float a_log_exp = expf(A_log_ptr[head_idx]);
+    if (threadIdx.x == 0) {
+        shared_storage.a_log_exp = expf(A_log_ptr[head_idx]);
+    }
     // --- Wait for TMA (q, k, beta, g_bf16, dt_bias)
     __syncthreads();
     shared_storage.tma_load_barrier.wait(0);
     cutlass::arch::fence_view_async_shared();
     __syncthreads();
 
-    // --- QK L2 Normalization ---
     int compute_tid = threadIdx.x;
+    int beta_smem_offset = (head_idx * T_total + int(bos) + local_t * CHUNK) & 7;
+    if (compute_tid < CHUNK) {
+        shared_storage.beta_act.begin()[compute_tid] = sigmoid_tanh_approx_f32(
+            float(shared_storage.beta.begin()[beta_smem_offset + compute_tid]));
+    }
+    int actual_len = min(CHUNK, seq_len - local_t * CHUNK);
+
+    // --- QK L2 Normalization ---
     {
         constexpr int ELEMS_PER_THREAD = 8;
         constexpr int THREADS_PER_ROW = D / ELEMS_PER_THREAD;  // 16
-        int my_row = threadIdx.x / THREADS_PER_ROW;
+        constexpr int ROWS_PER_PASS = NumThreads / THREADS_PER_ROW;
+        constexpr int ROW_PASSES = CHUNK / ROWS_PER_PASS;
+        static_assert(CHUNK % ROWS_PER_PASS == 0);
         int my_col = (threadIdx.x % THREADS_PER_ROW) * ELEMS_PER_THREAD;
 
         BF16* q_smem = shared_storage.q.begin();
         BF16* k_smem = shared_storage.k.begin();
+        using BF16x8 = cutlass::AlignedArray<BF16, ELEMS_PER_THREAD, 16>;
 
-        float q_vals[ELEMS_PER_THREAD], k_vals[ELEMS_PER_THREAD];
+        #pragma unroll
+        for (int pass = 0; pass < ROW_PASSES; ++pass) {
+        int my_row = pass * ROWS_PER_PASS + threadIdx.x / THREADS_PER_ROW;
+        int row_offset = my_row * D + my_col;
+        BF16x8 q_pack = *reinterpret_cast<BF16x8 const*>(q_smem + row_offset);
+        BF16x8 k_pack = *reinterpret_cast<BF16x8 const*>(k_smem + row_offset);
         float q_sq = 0.0f, k_sq = 0.0f;
 
         #pragma unroll
         for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
-            float qv = bf16_to_f32(q_smem[my_row * D + my_col + i]);
-            float kv = bf16_to_f32(k_smem[my_row * D + my_col + i]);
-            q_vals[i] = qv;
-            k_vals[i] = kv;
+            float qv = bf16_to_f32(q_pack[i]);
+            float kv = bf16_to_f32(k_pack[i]);
             q_sq += qv * qv;
             k_sq += kv * kv;
         }
 
         #pragma unroll
         for (int delta = 8; delta >= 1; delta >>= 1) {
-            q_sq += __shfl_xor_sync(0xFFFFFFFF, q_sq, delta);
-            k_sq += __shfl_xor_sync(0xFFFFFFFF, k_sq, delta);
+            q_sq += __shfl_xor_sync(0xFFFFFFFF, q_sq, delta, THREADS_PER_ROW);
+            k_sq += __shfl_xor_sync(0xFFFFFFFF, k_sq, delta, THREADS_PER_ROW);
         }
 
-        float q_inv = rsqrtf(q_sq + 1e-6f);
-        float k_inv = rsqrtf(k_sq + 1e-6f);
-
-        #pragma unroll
-        for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
-            q_smem[my_row * D + my_col + i] = BF16(q_vals[i] * q_inv);
-            k_smem[my_row * D + my_col + i] = BF16(k_vals[i] * k_inv);
+        if ((threadIdx.x % THREADS_PER_ROW) == 0) {
+            shared_storage.q_norm_inv.begin()[my_row] = rsqrtf(q_sq + 1e-6f);
+            shared_storage.k_norm_inv.begin()[my_row] = rsqrtf(k_sq + 1e-6f);
+        }
         }
     }
-    __syncthreads();
-
-    // --- Fused gate activation + cumsum + k tail zero-fill ---
-    // Threads 0-127: gate(g_bf16 + dt_bias) → cumulative sum, eliminates raw-g smem round-trip
-    // Threads 128-255: zero k for tail rows
-    {
-        int actual_len = min(CHUNK, seq_len - local_t * CHUNK);
-        if (compute_tid < 128) {
-            int col = compute_tid;
-            BF16 const* g_bf16_smem = shared_storage.g_bf16.begin();
-            float dt = shared_storage.dt_bias.begin()[col];
-            float* g_smem = shared_storage.g.begin();
-            float sum = 0.0f;
-            #pragma unroll
-            for (int row = 0; row < CHUNK; ++row) {
-                float g_val;
-                if (row < actual_len) {
-                    g_val = bf16_to_f32(g_bf16_smem[row * D + col]) + dt;
-                    g_val = a_log_exp * g_val;
-                    g_val = gate_scale * sigmoid_tanh_approx_f32(g_val);
-                } else {
-                    g_val = 0.0f;
-                }
-                sum += g_val;
-                g_smem[row * D + col] = sum;
+    // --- Fused gate activation + cumsum ---
+    // Q/K remain raw in shared memory. The decay pass consumes the row inverse
+    // norms above and rounds normalized values to BF16 directly in registers.
+    if (compute_tid < 128) {
+        int col = compute_tid;
+        BF16 const* g_bf16_smem = shared_storage.g_bf16.begin();
+        float dt = shared_storage.dt_bias.begin()[col];
+        float* g_smem = shared_storage.g.begin();
+        float sum = 0.0f;
+        #pragma unroll
+        for (int row = 0; row < CHUNK; ++row) {
+            float g_val;
+            if (row < actual_len) {
+                g_val = bf16_to_f32(g_bf16_smem[row * D + col]) + dt;
+                g_val = shared_storage.a_log_exp * g_val;
+                g_val = gate_scale * sigmoid_tanh_approx_f32(g_val);
+            } else {
+                g_val = 0.0f;
             }
-            shared_storage.g_total.begin()[col] = sum;
-        } else {
-            int col = compute_tid - 128;
-            BF16* k_smem = shared_storage.k.begin();
-            for (int row = actual_len; row < CHUNK; ++row) {
-                k_smem[row * D + col] = BF16(0);
-            }
+            sum += g_val;
+            g_smem[row * D + col] = sum;
         }
+        shared_storage.g_total.begin()[col] = sum;
     }
     __syncthreads();
 
     Tensor q_tile = make_tensor(make_smem_ptr(shared_storage.q.begin()), QKLayout{});
     Tensor k_tile = make_tensor(make_smem_ptr(shared_storage.k.begin()), QKLayout{});
     Tensor g_tile = make_tensor(make_smem_ptr(shared_storage.g.begin()), GLayout{});
-    Tensor beta_tile = make_tensor(make_smem_ptr(shared_storage.beta.begin()), BetaSmemLayout{});
-    int beta_smem_offset = (head_idx * T_total + int(bos) + local_t * CHUNK) & 7;
-
     Tensor k_restored = make_tensor(make_smem_ptr(shared_storage.k_restored.begin()), MMALayout{});
     Tensor k_decayed = make_tensor(make_smem_ptr(shared_storage.k_decayed.begin()), MMALayout{});
     Tensor q_decayed = make_tensor(make_smem_ptr(shared_storage.q_decayed.begin()), MMALayout{});
@@ -357,18 +345,26 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
         constexpr int N_M = CHUNK / 8;
         constexpr int N_N = D / 64;
         constexpr int N_TILES = N_M * N_N;
+        constexpr int PHYSICAL_WARPS = NumThreads / 32;
+        constexpr int WARP_PASSES = 8 / PHYSICAL_WARPS;
+        static_assert(8 % PHYSICAL_WARPS == 0);
 
-        float reg_g[N_TILES][2];
-        BF16  reg_q[N_TILES][2];
-        BF16  reg_k[N_TILES][2];
-        float reg_gt[N_TILES][2];
+        // Four physical warps cover the original eight warp assignments in
+        // two passes. Buffer every input before overwriting the union'd smem.
+        float reg_g[WARP_PASSES][N_TILES][2];
+        BF16  reg_q[WARP_PASSES][N_TILES][2];
+        BF16  reg_k[WARP_PASSES][N_TILES][2];
+        float reg_gt[WARP_PASSES][N_TILES][2];
 
         #pragma unroll
-        for (int m_blk = 0; m_blk < CHUNK; m_blk += 8) {
+        for (int pass = 0; pass < WARP_PASSES; ++pass) {
+            int virtual_warp_id = warp_id + pass * PHYSICAL_WARPS;
             #pragma unroll
-            for (int n_blk = 0; n_blk < D; n_blk += 64) {
+            for (int m_blk = 0; m_blk < CHUNK; m_blk += 8) {
+                #pragma unroll
+                for (int n_blk = 0; n_blk < D; n_blk += 64) {
                 int tile_idx = (m_blk / 8) * N_N + (n_blk / 64);
-                int row = m_blk + ((warp_id + g) % 8);
+                int row = m_blk + ((virtual_warp_id + g) % 8);
                 int col_base = n_blk + g * 8;
                 int col_tile = col_base / 8;
 
@@ -394,24 +390,29 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
 
                 #pragma unroll
                 for (int v = 0; v < 2; ++v) {
-                    reg_g[tile_idx][v]  = r_g(0, v);
-                    reg_q[tile_idx][v]  = r_q(0, v);
-                    reg_k[tile_idx][v]  = r_k(0, v);
-                    reg_gt[tile_idx][v] = r_gt(v);
+                    reg_g[pass][tile_idx][v]  = r_g(0, v);
+                    reg_q[pass][tile_idx][v]  = r_q(0, v);
+                    reg_k[pass][tile_idx][v]  = r_k(0, v);
+                    reg_gt[pass][tile_idx][v] = r_gt(v);
+                }
                 }
             }
         }
 
         // Sync before writing to union'd smem (q/k/g → k_decayed/q_decayed/k_inv)
-        // Safe: all 256 threads enter this if block (compute_tid < 256 always true)
+        // All virtual-warp inputs must be resident before any union'd output
+        // writes.
         __syncthreads();
 
         #pragma unroll
-        for (int m_blk = 0; m_blk < CHUNK; m_blk += 8) {
+        for (int pass = 0; pass < WARP_PASSES; ++pass) {
+            int virtual_warp_id = warp_id + pass * PHYSICAL_WARPS;
             #pragma unroll
-            for (int n_blk = 0; n_blk < D; n_blk += 64) {
+            for (int m_blk = 0; m_blk < CHUNK; m_blk += 8) {
+                #pragma unroll
+                for (int n_blk = 0; n_blk < D; n_blk += 64) {
                 int tile_idx = (m_blk / 8) * N_N + (n_blk / 64);
-                int row = m_blk + ((warp_id + g) % 8);
+                int row = m_blk + ((virtual_warp_id + g) % 8);
                 int col_base = n_blk + g * 8;
                 int col_tile = col_base / 8;
 
@@ -427,11 +428,13 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
 
                 Tensor r_qd = make_tensor_like<BF16>(s_qd);
                 Tensor r_kd = make_tensor_like<BF16>(s_kd);
+                float q_inv = shared_storage.q_norm_inv.begin()[row];
+                float k_inv_scale = shared_storage.k_norm_inv.begin()[row];
                 #pragma unroll
                 for (int v = 0; v < 2; ++v) {
-                    float g = reg_g[tile_idx][v];
-                    BF16 q = reg_q[tile_idx][v];
-                    BF16 k = reg_k[tile_idx][v];
+                    float g = reg_g[pass][tile_idx][v];
+                    BF16 q = BF16(bf16_to_f32(reg_q[pass][tile_idx][v]) * q_inv);
+                    BF16 k = row < actual_len ? BF16(bf16_to_f32(reg_k[pass][tile_idx][v]) * k_inv_scale) : BF16(0);
                     BF16 exp_cumsum = BF16(ex2_approx_ftz_f32(g));
                     r_qd(0, v) = q * exp_cumsum * BF16(scale);
                     r_kd(0, v) = k * exp_cumsum;
@@ -443,17 +446,17 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
                 Tensor r_kr = make_tensor_like<BF16>(s_kr);
                 #pragma unroll
                 for (int v = 0; v < 2; ++v) {
-                    float g = reg_g[tile_idx][v];
-                    BF16 k = reg_k[tile_idx][v];
+                    float g = reg_g[pass][tile_idx][v];
+                    BF16 k = row < actual_len ? BF16(bf16_to_f32(reg_k[pass][tile_idx][v]) * k_inv_scale) : BF16(0);
                     BF16 inv_cumsum = BF16(ex2_approx_ftz_f32(-g));
                     r_ki(0, v) = k * inv_cumsum;
-                    r_kr(0, v) = k * inv_cumsum * BF16(reg_gt[tile_idx][v]);
+                    r_kr(0, v) = k * inv_cumsum * BF16(reg_gt[pass][tile_idx][v]);
                 }
                 cute::copy(AutoVectorizingCopy{}, r_ki, s_ki);
                 cute::copy(AutoVectorizingCopy{}, r_kr, s_kr);
+                }
             }
         }
-
     }
     __syncthreads();
 
@@ -473,15 +476,15 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     Tensor INV_fp16 = make_tensor(make_smem_ptr(reinterpret_cast<FP16*>(shared_storage.INV.begin())), LMLayout{});
 
 // tril_IL + INV = I - L (merged, same thread same element)
-    if (compute_tid < 256) {
+    for (int matrix_idx = compute_tid; matrix_idx < CHUNK * CHUNK; matrix_idx += NumThreads) {
         const int col_block_size = 8;
-        int block_idx = compute_tid / (CHUNK * col_block_size);
-        int i = (compute_tid / col_block_size) % CHUNK;
-        int j = compute_tid % col_block_size + block_idx * col_block_size;
+        int block_idx = matrix_idx / (CHUNK * col_block_size);
+        int i = (matrix_idx / col_block_size) % CHUNK;
+        int j = matrix_idx % col_block_size + block_idx * col_block_size;
         if (i <= j) {
             L_fp16(i, j) = FP16::bitcast(0);
         } else {
-            L_fp16(i, j) = L_fp16(i, j) * FP16(sigmoid_tanh_approx_f32(float(beta_tile(beta_smem_offset + i))));
+            L_fp16(i, j) = L_fp16(i, j) * FP16(shared_storage.beta_act.begin()[i]);
         }
         if (i < j) {
             Mqk(i, j) = BF16::bitcast(0);
@@ -499,72 +502,38 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
     __syncthreads();
     if (threadIdx.x == 0) {
         int ws_idx = head_idx * total_tiles + global_tile_idx;
-        // Store k_decayed [CHUNK, D] bf16
-        {
-            auto g_ws = tma_store_ws_kd.get_tma_tensor(make_shape(H * total_tiles, CHUNK, D));
-            auto ws_off = g_ws.layout()(ws_idx, 0, 0);
-            Tensor g_ws_tile = make_tensor(g_ws.data() + ws_off,
-                make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws.layout())));
-            Tensor s_kd = make_tensor(make_smem_ptr(shared_storage.k_decayed.begin()), TMAVOLayout{});
-            auto cta_tma = tma_store_ws_kd.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_kd, cta_tma.partition_S(s_kd), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
-        }
-        // Store q_decayed
-        {
-            auto g_ws = tma_store_ws_qd.get_tma_tensor(make_shape(H * total_tiles, CHUNK, D));
-            auto ws_off = g_ws.layout()(ws_idx, 0, 0);
-            Tensor g_ws_tile = make_tensor(g_ws.data() + ws_off,
-                make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws.layout())));
-            Tensor s_qd = make_tensor(make_smem_ptr(shared_storage.q_decayed.begin()), TMAVOLayout{});
-            auto cta_tma = tma_store_ws_qd.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_qd, cta_tma.partition_S(s_qd), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
-        }
-        // Store k_restored
-        {
-            auto g_ws = tma_store_ws_kr.get_tma_tensor(make_shape(H * total_tiles, CHUNK, D));
-            auto ws_off = g_ws.layout()(ws_idx, 0, 0);
-            Tensor g_ws_tile = make_tensor(g_ws.data() + ws_off,
-                make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws.layout())));
-            Tensor s_kr = make_tensor(make_smem_ptr(shared_storage.k_restored.begin()), TMAVOLayout{});
-            auto cta_tma = tma_store_ws_kr.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_kr, cta_tma.partition_S(s_kr), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
-        }
-        // Store g_total [D] float
-        {
-            auto g_ws = tma_store_ws_gt.get_tma_tensor(make_shape(H * total_tiles, D));
-            auto ws_off = g_ws.layout()(ws_idx, 0);
-            Tensor g_ws_tile = make_tensor(g_ws.data() + ws_off,
-                make_layout(make_shape(Int<1>{}, Int<D>{}), stride(g_ws.layout())));
-            Tensor s_gt = make_tensor(make_smem_ptr(shared_storage.g_total.begin()), TMAGTotalSmemLayout{});
-            auto cta_tma = tma_store_ws_gt.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_gt, cta_tma.partition_S(s_gt), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
-        }
-        // Store INV [CHUNK, CHUNK] bf16
-        {
-            auto g_ws = tma_store_ws_inv.get_tma_tensor(make_shape(H * total_tiles, CHUNK, CHUNK));
-            auto ws_off = g_ws.layout()(ws_idx, 0, 0);
-            Tensor g_ws_tile = make_tensor(g_ws.data() + ws_off,
-                make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<CHUNK>{}), stride(g_ws.layout())));
-            Tensor s_inv = make_tensor(make_smem_ptr(shared_storage.INV.begin()), TMALMLayout{});
-            auto cta_tma = tma_store_ws_inv.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_inv, cta_tma.partition_S(s_inv), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
-        }
-        // Store Mqk [CHUNK, CHUNK] bf16
-        {
-            auto g_ws = tma_store_ws_mqk.get_tma_tensor(make_shape(H * total_tiles, CHUNK, CHUNK));
-            auto ws_off = g_ws.layout()(ws_idx, 0, 0);
-            Tensor g_ws_tile = make_tensor(g_ws.data() + ws_off,
-                make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<CHUNK>{}), stride(g_ws.layout())));
-            Tensor s_mqk = make_tensor(make_smem_ptr(shared_storage.Mqk.begin()), TMALMLayout{});
-            auto cta_tma = tma_store_ws_mqk.get_slice(Int<0>{});
-            cute::copy(tma_store_ws_mqk, cta_tma.partition_S(s_mqk), cta_tma.partition_D(g_ws_tile));
-            tma_store_arrive();
-        }
+
+        // Private K1→K2 ABI: preserve each swizzled shared-memory byte image
+        // so K2 can restore it directly without TensorMap segmentation.
+        BF16* k_decayed_dst = ws_kd + int64_t(ws_idx) * (CHUNK * D);
+        cute::SM90_BULK_COPY_S2G::copy(
+            shared_storage.k_decayed.begin(), k_decayed_dst, int32_t(CHUNK * D * sizeof(BF16)));
+        tma_store_arrive();
+
+        BF16* q_decayed_dst = ws_qd + int64_t(ws_idx) * (CHUNK * D);
+        cute::SM90_BULK_COPY_S2G::copy(
+            shared_storage.q_decayed.begin(), q_decayed_dst, int32_t(CHUNK * D * sizeof(BF16)));
+        tma_store_arrive();
+
+        BF16* k_restored_dst = ws_kr + int64_t(ws_idx) * (CHUNK * D);
+        cute::SM90_BULK_COPY_S2G::copy(
+            shared_storage.k_restored.begin(), k_restored_dst, int32_t(CHUNK * D * sizeof(BF16)));
+        tma_store_arrive();
+
+        float* g_total_dst = ws_gt + int64_t(ws_idx) * D;
+        cute::SM90_BULK_COPY_S2G::copy(
+            shared_storage.g_total.begin(), g_total_dst, int32_t(D * sizeof(float)));
+        tma_store_arrive();
+
+        BF16* inv_dst = ws_inv + int64_t(ws_idx) * (CHUNK * CHUNK);
+        cute::SM90_BULK_COPY_S2G::copy(
+            shared_storage.INV.begin(), inv_dst, int32_t(CHUNK * CHUNK * sizeof(BF16)));
+        tma_store_arrive();
+
+        BF16* mqk_dst = ws_mqk + int64_t(ws_idx) * (CHUNK * CHUNK);
+        cute::SM90_BULK_COPY_S2G::copy(
+            shared_storage.Mqk.begin(), mqk_dst, int32_t(CHUNK * CHUNK * sizeof(BF16)));
+        tma_store_arrive();
     }
     tma_store_wait<0>();
     __syncthreads();

--- a/csrc/smxx/fwd_kernel1.cuh
+++ b/csrc/smxx/fwd_kernel1.cuh
@@ -534,9 +534,5 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
         cute::SM90_BULK_COPY_S2G::copy(
             shared_storage.Mqk.begin(), mqk_dst, int32_t(CHUNK * CHUNK * sizeof(BF16)));
         tma_store_arrive();
-
-        // The initiating thread must keep shared memory alive until every
-        // bulk store has finished reading its source.
-        tma_store_wait<0>();
     }
 }

--- a/csrc/smxx/fwd_kernel1.cuh
+++ b/csrc/smxx/fwd_kernel1.cuh
@@ -534,7 +534,9 @@ __global__ void __launch_bounds__(NumThreads, 8) _flash_kda_fwd_prepare(
         cute::SM90_BULK_COPY_S2G::copy(
             shared_storage.Mqk.begin(), mqk_dst, int32_t(CHUNK * CHUNK * sizeof(BF16)));
         tma_store_arrive();
+
+        // The initiating thread must keep shared memory alive until every
+        // bulk store has finished reading its source.
+        tma_store_wait<0>();
     }
-    tma_store_wait<0>();
-    __syncthreads();
 }

--- a/csrc/smxx/fwd_kernel2.cuh
+++ b/csrc/smxx/fwd_kernel2.cuh
@@ -1,9 +1,5 @@
 #pragma once
 
-// TMA_DISABLE_ALL: when defined, disable load/store warps entirely
-// and let MMA warps work without pipeline synchronization
-// #define TMA_DISABLE_ALL
-
 #include "utils.cuh"
 
 template <int D, int CHUNK = 16>
@@ -19,7 +15,6 @@ struct K2Layouts {
         LayoutRight{}
     ));
     using VOLayout = MMALayout;
-    using TransposedVOLayout = TransposedMMALayout;
     using BetaSmemLayout = Layout<Shape<Int<32>>, Stride<Int<1>>>;
     using StateSmemLayout = decltype(tile_to_shape(
         GMMA::Layout_K_INTER_Atom<cute::bfloat16_t>{},
@@ -49,12 +44,6 @@ struct K2Layouts {
         StateSmemLayout{}.offset(),
         prepend(StateSmemLayout{}.layout_b())
     ));
-    using TMALMLayout = decltype(composition(
-        LMLayout{}.layout_a(),
-        LMLayout{}.offset(),
-        prepend(LMLayout{}.layout_b())
-    ));
-    using TMAGTotalSmemLayout = decltype(prepend(GTotalLayout{}));
 
     // FP32 state layout (K_SW32 atom, same 8x8 atom structure as K_INTER bf16)
     using FP32StateSmemLayout = decltype(tile_to_shape(
@@ -111,12 +100,26 @@ struct SharedStorageK2 {
     alignas(16) cutlass::arch::ClusterTransactionBarrier state_acc_tma_barrier;
 };
 
+template <class CFragment, class BFragment>
+CUTLASS_DEVICE void movm_transpose_c_to_b_16x16(
+    CFragment const& source,
+    BFragment& destination
+) {
+    static_assert(sizeof(CFragment) == 4 * sizeof(uint32_t));
+    static_assert(sizeof(BFragment) == 4 * sizeof(uint32_t));
+
+    auto const* source_regs = reinterpret_cast<uint32_t const*>(&source(0));
+    auto* destination_regs = reinterpret_cast<uint32_t*>(&destination(0));
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        SM75_U32x1_MOVM_T::copy(source_regs[i], destination_regs[i]);
+    }
+}
+
 // ==================== Kernel 2: Recurrence ====================
 template <
     class TmaLoadV,
     class TmaLoadBeta,
-    class TmaLoadWsKD, class TmaLoadWsQD, class TmaLoadWsKR,
-    class TmaLoadWsGT, class TmaLoadWsINV, class TmaLoadWsMqk,
     class TmaLoadState,
     class TmaStoreState,
     class TmaStoreOut,
@@ -131,15 +134,9 @@ template <
     bool IsVarlen = true,
     typename SeqlenT = int64_t
 >
-__global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
+__global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
     CUTE_GRID_CONSTANT TmaLoadV const tma_load_v,
     CUTE_GRID_CONSTANT TmaLoadBeta const tma_load_beta,
-    CUTE_GRID_CONSTANT TmaLoadWsKD const tma_load_ws_kd,
-    CUTE_GRID_CONSTANT TmaLoadWsQD const tma_load_ws_qd,
-    CUTE_GRID_CONSTANT TmaLoadWsKR const tma_load_ws_kr,
-    CUTE_GRID_CONSTANT TmaLoadWsGT const tma_load_ws_gt,
-    CUTE_GRID_CONSTANT TmaLoadWsINV const tma_load_ws_inv,
-    CUTE_GRID_CONSTANT TmaLoadWsMqk const tma_load_ws_mqk,
     CUTE_GRID_CONSTANT TmaLoadState const tma_load_initial_state,
     CUTE_GRID_CONSTANT TmaStoreState const tma_store_final_state,
     CUTE_GRID_CONSTANT TmaStoreOut const tma_store_out,
@@ -148,15 +145,19 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     int H,
     int N,
     SeqlenT const* cu_seqlens,
-    int total_tiles
+    int total_tiles,
+    cutlass::bfloat16_t const* ws_kd,
+    cutlass::bfloat16_t const* ws_qd,
+    cutlass::bfloat16_t const* ws_kr,
+    float const* ws_gt,
+    cutlass::bfloat16_t const* ws_inv,
+    cutlass::bfloat16_t const* ws_mqk
 ) {
     using BF16 = cutlass::bfloat16_t;
-    using FP16 = cutlass::half_t;
     using Layouts = K2Layouts<D, CHUNK>;
     using MMALayout = typename Layouts::MMALayout;
     using TransposedMMALayout = typename Layouts::TransposedMMALayout;
     using VOLayout = typename Layouts::VOLayout;
-    using TransposedVOLayout = typename Layouts::TransposedVOLayout;
     using BetaSmemLayout = typename Layouts::BetaSmemLayout;
     using StateSmemLayout = typename Layouts::StateSmemLayout;
     using TransposedStateSmemLayout = typename Layouts::TransposedStateSmemLayout;
@@ -165,26 +166,23 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     using TMAVOLayout = typename Layouts::TMAVOLayout;
     using TMABetaSmemLayout = typename Layouts::TMABetaSmemLayout;
     using TMAStateSmemLayout = typename Layouts::TMAStateSmemLayout;
-    using TMALMLayout = typename Layouts::TMALMLayout;
-    using TMAGTotalSmemLayout = typename Layouts::TMAGTotalSmemLayout;
+    using SharedStorageT = SharedStorageK2<Layouts, InputStages, OutputStages>;
+
+    // --- shared memory
+    extern __shared__ __align__(128) unsigned char shared_mem[];
+    SharedStorageT& shared_storage =
+        *reinterpret_cast<SharedStorageT*>(shared_mem);
+
     constexpr int kWarpSize = 32;
     constexpr int kComputeThreads = 128;
 
     // Transaction bytes: v + beta + k_decayed + q_decayed + k_restored + g_total + INV + Mqk
     constexpr uint32_t kTmaTransactionBytes =
-#ifndef TMA_DISABLE_ALL
         uint32_t(cute::cosize_v<VOLayout>) * uint32_t(sizeof(BF16)) +
         uint32_t(32) * uint32_t(sizeof(BF16)) +  // beta (bf16, sigmoid fused)
-        uint32_t(cute::cosize_v<MMALayout>) * uint32_t(sizeof(BF16)) * 3 +  // k_decayed, q_decayed, k_restored
-        uint32_t(cute::cosize_v<GTotalLayout>) * uint32_t(sizeof(float)) +    // g_total
-        uint32_t(cute::cosize_v<LMLayout>) * uint32_t(sizeof(BF16)) * 2 +    // INV, Mqk
-#endif
-        0u;
-
-    // --- shared memory
-    extern __shared__ __align__(128) unsigned char shared_mem[];
-    using SharedStorageT = SharedStorageK2<Layouts, InputStages, OutputStages>;
-    SharedStorageT& shared_storage = *reinterpret_cast<SharedStorageT*>(shared_mem);
+        uint32_t(cute::cosize_v<MMALayout>) * uint32_t(sizeof(BF16)) * 3 +
+        uint32_t(cute::cosize_v<GTotalLayout>) * uint32_t(sizeof(float)) +
+        uint32_t(cute::cosize_v<LMLayout>) * uint32_t(sizeof(BF16)) * 2;
 
     // --- warp specialization
     int warp_id = threadIdx.x / kWarpSize;
@@ -197,7 +195,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
         warp_role = WarpRole::STORE;
     }
 
-#ifndef TMA_DISABLE_ALL
     using LoadPipelineState = cutlass::PipelineState<InputStages>;
     using LoadPipeline = cutlass::PipelineTmaAsync<InputStages>;
     LoadPipeline load_pipeline = make_load_pipeline<InputStages>(
@@ -211,11 +208,15 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
         shared_storage.store_pipeline,
         warp_role, kComputeThreads, 1
     );
-#endif
 
     // --- per-block sequence info
-    int seq_idx  = blockIdx.x;
-    int head_idx = blockIdx.y;
+    int head_idx = int(blockIdx.x);
+    int seq_idx = int(blockIdx.y);
+    if constexpr (IsVarlen) {
+        // vLLM orders decodes before prefills. Reverse that order so the
+        // long-running prefill CTAs are issued first.
+        seq_idx = N - 1 - seq_idx;
+    }
     int64_t bos, eos;
     int tile_base;
 
@@ -238,7 +239,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     bool lane_predicate = cute::elect_one_sync();
 
     // --- Load initial state
-#ifndef TMA_DISABLE_ALL
     if constexpr (HasStateIn && !StateFP32) {
         // BF16 state: TMA load directly into state_acc
         if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
@@ -312,9 +312,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
         }
         __syncthreads();
     }
-#endif
-
-#ifndef TMA_DISABLE_ALL
     __syncthreads();
 
     // --- LOAD warp: issue TMA loads for v, beta, and workspace intermediates
@@ -322,23 +319,9 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
         Tensor g_v = tma_load_v.get_tma_tensor(make_shape(H, T_total, D));
         Tensor g_beta = tma_load_beta.get_tma_tensor(make_shape(H * T_total));
 
-        // Workspace gmem tensors
-        auto g_ws_kd = tma_load_ws_kd.get_tma_tensor(make_shape(H * total_tiles, CHUNK, D));
-        auto g_ws_qd = tma_load_ws_qd.get_tma_tensor(make_shape(H * total_tiles, CHUNK, D));
-        auto g_ws_kr = tma_load_ws_kr.get_tma_tensor(make_shape(H * total_tiles, CHUNK, D));
-        auto g_ws_gt = tma_load_ws_gt.get_tma_tensor(make_shape(H * total_tiles, D));
-        auto g_ws_inv = tma_load_ws_inv.get_tma_tensor(make_shape(H * total_tiles, CHUNK, CHUNK));
-        auto g_ws_mqk = tma_load_ws_mqk.get_tma_tensor(make_shape(H * total_tiles, CHUNK, CHUNK));
-
         LoadPipelineState load_write = cutlass::make_producer_start_state<LoadPipeline>();
         auto cta_tma_load_v = tma_load_v.get_slice(Int<0>{});
         auto cta_tma_load_beta = tma_load_beta.get_slice(Int<0>{});
-        auto cta_ws_kd = tma_load_ws_kd.get_slice(Int<0>{});
-        auto cta_ws_qd = tma_load_ws_qd.get_slice(Int<0>{});
-        auto cta_ws_kr = tma_load_ws_kr.get_slice(Int<0>{});
-        auto cta_ws_gt = tma_load_ws_gt.get_slice(Int<0>{});
-        auto cta_ws_inv = tma_load_ws_inv.get_slice(Int<0>{});
-        auto cta_ws_mqk = tma_load_ws_mqk.get_slice(Int<0>{});
 
         for (int t = 0; t < t_tiles; ++t) {
             load_pipeline.producer_acquire(load_write);
@@ -364,80 +347,98 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             cute::copy(tma_load_beta.with(*tma_barrier),
                 cta_tma_load_beta.partition_S(g_beta_tile), cta_tma_load_beta.partition_D(s_beta_tile));
 
-            // TMA load workspace: k_decayed
-            {
-                auto off = g_ws_kd.layout()(ws_idx, 0, 0);
-                Tensor g_tile = make_tensor(g_ws_kd.data() + off,
-                    make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws_kd.layout())));
-                Tensor s_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].k_decayed.begin()), TMAVOLayout{});
-                cute::copy(tma_load_ws_kd.with(*tma_barrier), cta_ws_kd.partition_S(g_tile), cta_ws_kd.partition_D(s_tile));
-            }
-            // q_decayed
-            {
-                auto off = g_ws_qd.layout()(ws_idx, 0, 0);
-                Tensor g_tile = make_tensor(g_ws_qd.data() + off,
-                    make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws_qd.layout())));
-                Tensor s_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].q_decayed.begin()), TMAVOLayout{});
-                cute::copy(tma_load_ws_qd.with(*tma_barrier), cta_ws_qd.partition_S(g_tile), cta_ws_qd.partition_D(s_tile));
-            }
-            // k_restored
-            {
-                auto off = g_ws_kr.layout()(ws_idx, 0, 0);
-                Tensor g_tile = make_tensor(g_ws_kr.data() + off,
-                    make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<D>{}), stride(g_ws_kr.layout())));
-                Tensor s_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].k_restored.begin()), TMAVOLayout{});
-                cute::copy(tma_load_ws_kr.with(*tma_barrier), cta_ws_kr.partition_S(g_tile), cta_ws_kr.partition_D(s_tile));
-            }
-            // g_total
-            {
-                auto off = g_ws_gt.layout()(ws_idx, 0);
-                Tensor g_tile = make_tensor(g_ws_gt.data() + off,
-                    make_layout(make_shape(Int<1>{}, Int<D>{}), stride(g_ws_gt.layout())));
-                Tensor s_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].g_total.begin()), TMAGTotalSmemLayout{});
-                cute::copy(tma_load_ws_gt.with(*tma_barrier), cta_ws_gt.partition_S(g_tile), cta_ws_gt.partition_D(s_tile));
-            }
-            // INV
-            {
-                auto off = g_ws_inv.layout()(ws_idx, 0, 0);
-                Tensor g_tile = make_tensor(g_ws_inv.data() + off,
-                    make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<CHUNK>{}), stride(g_ws_inv.layout())));
-                Tensor s_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].INV.begin()), TMALMLayout{});
-                cute::copy(tma_load_ws_inv.with(*tma_barrier), cta_ws_inv.partition_S(g_tile), cta_ws_inv.partition_D(s_tile));
-            }
-            // Mqk
-            {
-                auto off = g_ws_mqk.layout()(ws_idx, 0, 0);
-                Tensor g_tile = make_tensor(g_ws_mqk.data() + off,
-                    make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<CHUNK>{}), stride(g_ws_mqk.layout())));
-                Tensor s_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].Mqk.begin()), TMALMLayout{});
-                cute::copy(tma_load_ws_mqk.with(*tma_barrier), cta_ws_mqk.partition_S(g_tile), cta_ws_mqk.partition_D(s_tile));
-            }
+            // K1 stores byte images of its swizzled shared-memory tensors.
+            // K2 uses the same layouts, so raw bulk copies restore them
+            // directly without tensor-map coordinate work or repacking.
+            cute::SM90_BULK_COPY_G2S::copy(
+                ws_kd + int64_t(ws_idx) * (CHUNK * D),
+                reinterpret_cast<uint64_t*>(tma_barrier),
+                shared_storage.input[stage].k_decayed.begin(),
+                int32_t(CHUNK * D * sizeof(BF16)));
+            cute::SM90_BULK_COPY_G2S::copy(
+                ws_qd + int64_t(ws_idx) * (CHUNK * D),
+                reinterpret_cast<uint64_t*>(tma_barrier),
+                shared_storage.input[stage].q_decayed.begin(),
+                int32_t(CHUNK * D * sizeof(BF16)));
+            cute::SM90_BULK_COPY_G2S::copy(
+                ws_kr + int64_t(ws_idx) * (CHUNK * D),
+                reinterpret_cast<uint64_t*>(tma_barrier),
+                shared_storage.input[stage].k_restored.begin(),
+                int32_t(CHUNK * D * sizeof(BF16)));
+            cute::SM90_BULK_COPY_G2S::copy(
+                ws_gt + int64_t(ws_idx) * D,
+                reinterpret_cast<uint64_t*>(tma_barrier),
+                shared_storage.input[stage].g_total.begin(),
+                int32_t(D * sizeof(float)));
+            cute::SM90_BULK_COPY_G2S::copy(
+                ws_inv + int64_t(ws_idx) * (CHUNK * CHUNK),
+                reinterpret_cast<uint64_t*>(tma_barrier),
+                shared_storage.input[stage].INV.begin(),
+                int32_t(CHUNK * CHUNK * sizeof(BF16)));
+            cute::SM90_BULK_COPY_G2S::copy(
+                ws_mqk + int64_t(ws_idx) * (CHUNK * CHUNK),
+                reinterpret_cast<uint64_t*>(tma_barrier),
+                shared_storage.input[stage].Mqk.begin(),
+                int32_t(CHUNK * CHUNK * sizeof(BF16)));
 
             ++load_write;
         }
         load_pipeline.producer_tail(load_write);
     }
-#endif
 
     // --- MMA warps
     if (warp_role == WarpRole::MMA) {
-        cutlass::arch::NamedBarrier compute_barrier(kComputeThreads, 0);
-#ifndef TMA_DISABLE_ALL
         LoadPipelineState load_read;
         StorePipelineState out_write = cutlass::make_producer_start_state<StorePipeline>();
-#endif
         int compute_tid = threadIdx.x;
 
+        // Keep this warp's 32 value columns of the recurrent [K,V] state in
+        // BF16 C fragments for the entire chunk loop. Phase 1 transposes each
+        // fragment into an MMA-B operand with MOVM_T; Phase 6 updates the C
+        // fragment in place. Shared memory is touched only at entry and, when
+        // requested, once more before the final-state TMA store.
+        Tensor resident_s_acc_T = make_tensor(
+            make_smem_ptr(shared_storage.state_acc.begin()),
+            TransposedStateSmemLayout{});
+        auto resident_mma = make_tiled_mma(
+            MMA_Atom<SM80_16x8x16_F32BF16BF16F32_TN>{},
+            Layout<Shape<_1,_1>>{},
+            Tile<_16,_16,_16>{});
+        const int resident_warp_id = compute_tid / kWarpSize;
+        const int resident_lane_id = compute_tid % kWarpSize;
+        auto resident_thr_mma = resident_mma.get_slice(resident_lane_id);
+        auto resident_load_c = make_tiled_copy_C(
+            Copy_Atom<SM75_U16x8_LDSM_T, BF16>{}, resident_mma);
+        auto resident_thr_load_c = resident_load_c.get_slice(resident_lane_id);
+        Tensor resident_state_ref = local_tile(
+            resident_s_acc_T,
+            make_shape(Int<16>{}, Int<16>{}),
+            make_coord(0, resident_warp_id * 2));
+        auto resident_c_ref = resident_thr_mma.partition_C(resident_state_ref);
+        using ResidentStateFragment = decltype(make_fragment_like<BF16>(
+            resident_thr_mma.make_fragment_C(resident_c_ref)));
+        constexpr int kResidentStateRowBlocks = D / 16;
+        ResidentStateFragment resident_state[2][kResidentStateRowBlocks];
+
+        #pragma unroll
+        for (int m = 0; m < kResidentStateRowBlocks; ++m) {
+            #pragma unroll
+            for (int bi = 0; bi < 2; ++bi) {
+                Tensor state_block = local_tile(
+                    resident_s_acc_T,
+                    make_shape(Int<16>{}, Int<16>{}),
+                    make_coord(m, resident_warp_id * 2 + bi));
+                copy(
+                    resident_load_c,
+                    resident_thr_load_c.partition_S(state_block),
+                    resident_thr_load_c.retile_D(resident_state[bi][m]));
+            }
+        }
+
         for (int t = 0; t < t_tiles; ++t) {
-#ifndef TMA_DISABLE_ALL
-            store_pipeline.producer_acquire(out_write);
             load_pipeline.consumer_wait(load_read);
             int load_stage = load_read.index();
             int out_stage = out_write.index();
-#else
-            constexpr int load_stage = 0;
-            constexpr int out_stage = 0;
-#endif
 
             Tensor v_tile = make_tensor(make_smem_ptr(shared_storage.input[load_stage].v.begin()), VOLayout{});
             Tensor beta_tile = make_tensor(make_smem_ptr(shared_storage.input[load_stage].beta.begin()), BetaSmemLayout{});
@@ -446,7 +447,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
 
             Tensor k_decayed = make_tensor(make_smem_ptr(shared_storage.input[load_stage].k_decayed.begin()), MMALayout{});
             Tensor q_decayed = make_tensor(make_smem_ptr(shared_storage.input[load_stage].q_decayed.begin()), MMALayout{});
-            Tensor k_restored = make_tensor(make_smem_ptr(shared_storage.input[load_stage].k_restored.begin()), MMALayout{});
             Tensor g_total = make_tensor(make_smem_ptr(shared_storage.input[load_stage].g_total.begin()), GTotalLayout{});
             Tensor INV = make_tensor(make_smem_ptr(shared_storage.input[load_stage].INV.begin()), LMLayout{});
             Tensor Mqk = make_tensor(make_smem_ptr(shared_storage.input[load_stage].Mqk.begin()), LMLayout{});
@@ -459,8 +459,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             // U stays in registers via SM75_U32x1_MOVM_T (no smem round-trip)
             {
             Tensor k_restored_t = make_tensor(make_smem_ptr(shared_storage.input[load_stage].k_restored.begin()), TransposedMMALayout{});
-
-            constexpr int PREFETCH = 1;
 
             auto mma = make_tiled_mma(
                 MMA_Atom<SM80_16x8x16_F32BF16BF16F32_TN>{},
@@ -482,10 +480,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             auto smem_tiled_copy_A_T = make_tiled_copy_A(Copy_Atom<SM75_U16x8_LDSM_T, BF16>{}, mma);
             auto smem_thr_copy_A_T   = smem_tiled_copy_A_T.get_thread_slice(lane_id);
 
-            // B copy: K_INTER → LDSM_N
-            auto smem_tiled_copy_B = make_tiled_copy_B(Copy_Atom<SM75_U32x4_LDSM_N, BF16>{}, mma);
-            auto smem_thr_copy_B   = smem_tiled_copy_B.get_thread_slice(lane_id);
-
             // C load/store
             auto smem_tiled_load_C  = make_tiled_copy_C(Copy_Atom<SM75_U32x4_LDSM_N, BF16>{}, mma);
             auto smem_thr_load_C    = smem_tiled_load_C.get_slice(lane_id);
@@ -493,8 +487,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             auto smem_thr_store_C   = smem_tiled_store_C.get_slice(lane_id);
 
             // C load/store transposed (for Phase 6 state access via s_acc_T)
-            auto smem_tiled_load_C_T  = make_tiled_copy_C(Copy_Atom<SM75_U16x8_LDSM_T, BF16>{}, mma);
-            auto smem_thr_load_C_T    = smem_tiled_load_C_T.get_slice(lane_id);
             auto smem_tiled_store_C_T = make_tiled_copy_C(Copy_Atom<SM90_U16x8_STSM_T, BF16>{}, mma);
             auto smem_thr_store_C_T   = smem_tiled_store_C_T.get_slice(lane_id);
 
@@ -510,8 +502,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             auto tCrAi_q_view = smem_thr_copy_A.retile_D(tCrAi_q);
             auto tCrA_q = thr_mma.partition_fragment_A(A_ref);
 
-            Tensor tCrBi = make_fragment_like<BF16>(thr_mma.partition_fragment_B(B_ref));
-            auto tCrBi_view = smem_thr_copy_B.retile_D(tCrBi);
             auto tCrB = thr_mma.partition_fragment_B(B_ref);
 
             auto tCrC_ref = thr_mma.partition_C(C_ref);
@@ -530,38 +520,33 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             // ======== Phase 1: Dual GEMM k@s and q@s (k-loop, 2 blocks per warp) ========
             constexpr int K_BLOCKS = decltype(cute::size<1>(k_decayed))::value / 16;
 
+            {
             copy(smem_tiled_copy_A, smem_thr_copy_A.partition_S(
                 local_tile(k_decayed, make_shape(Int<16>{}, Int<16>{}), make_coord(0, 0))), tCrAi_k_view);
             copy(smem_tiled_copy_A, smem_thr_copy_A.partition_S(
                 local_tile(q_decayed, make_shape(Int<16>{}, Int<16>{}), make_coord(0, 0))), tCrAi_q_view);
-            copy(smem_tiled_copy_B, smem_thr_copy_B.partition_S(
-                local_tile(s_acc, make_shape(Int<16>{}, Int<16>{}), make_coord(warp_id * 2, 0))), tCrBi_view);
 
             #pragma unroll
             for (int k = 0; k < K_BLOCKS; ++k) {
                 cute::transform(tCrAi_k, tCrA_k, cute::identity{});
                 cute::transform(tCrAi_q, tCrA_q, cute::identity{});
-                cute::transform(tCrBi, tCrB, cute::identity{});
-
-                copy(smem_tiled_copy_B, smem_thr_copy_B.partition_S(
-                    local_tile(s_acc, make_shape(Int<16>{}, Int<16>{}), make_coord(warp_id * 2 + 1, k))), tCrBi_view);
+                movm_transpose_c_to_b_16x16(resident_state[0][k], tCrB);
 
                 gemm(thr_mma, tCrA_k(_,_,Int<0>{}), tCrB(_,_,Int<0>{}), u_acc[0]);
                 gemm(thr_mma, tCrA_q(_,_,Int<0>{}), tCrB(_,_,Int<0>{}), out_acc[0]);
 
-                cute::transform(tCrBi, tCrB, cute::identity{});
+                movm_transpose_c_to_b_16x16(resident_state[1][k], tCrB);
 
                 if (k + 1 < K_BLOCKS) {
                     copy(smem_tiled_copy_A, smem_thr_copy_A.partition_S(
                         local_tile(k_decayed, make_shape(Int<16>{}, Int<16>{}), make_coord(0, k + 1))), tCrAi_k_view);
                     copy(smem_tiled_copy_A, smem_thr_copy_A.partition_S(
                         local_tile(q_decayed, make_shape(Int<16>{}, Int<16>{}), make_coord(0, k + 1))), tCrAi_q_view);
-                    copy(smem_tiled_copy_B, smem_thr_copy_B.partition_S(
-                        local_tile(s_acc, make_shape(Int<16>{}, Int<16>{}), make_coord(warp_id * 2, k + 1))), tCrBi_view);
                 }
 
                 gemm(thr_mma, tCrA_k(_,_,Int<0>{}), tCrB(_,_,Int<0>{}), u_acc[1]);
                 gemm(thr_mma, tCrA_q(_,_,Int<0>{}), tCrB(_,_,Int<0>{}), out_acc[1]);
+            }
             }
 
             // ======== Phase 2: Cast out (keep in regs), load v/INV/beta ========
@@ -646,6 +631,10 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
                 cute::transform(out_bf16[i], gemm_bf16, out_bf16[i], [] __device__ (BF16 c, BF16 a) { return c + a; });
             }
 
+            // Late output-acquire (cycle trim): first out-stage write is in
+            // phase 5, so ownership is needed only now; the wait typically
+            // finds the stage already released.
+            store_pipeline.producer_acquire(out_write);
             // ======== Phase 5: Store final out ========
             #pragma unroll
             for (int i = 0; i < 2; ++i) {
@@ -657,13 +646,13 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
             // s_acc[D, D] = s_acc * g_total + k_restored_t[D, 16] @ U[16, D]
             // Each warp handles columns [warp_id*32, (warp_id+1)*32] = 2 x 16x16 blocks
             // U is already in tCrB_u_arr[0..1] as B operands (from Phase 4 MOVM_T)
+            constexpr int PREFETCH = 1;
             constexpr int S_M_BLOCKS = decltype(cute::size<0>(k_restored_t))::value / 16;
 
             Tensor tCrAi_kr = make_fragment_like<BF16>(thr_mma.partition_fragment_A(A_ref));
             auto tCrAi_kr_view = smem_thr_copy_A_T.retile_D(tCrAi_kr);
 
             AFragT ring_A_kr[PREFETCH];
-            SFragT ring_S_acc[2][PREFETCH];
             float ring_g0[PREFETCH], ring_g1[PREFETCH];
 
             #pragma unroll
@@ -671,12 +660,6 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
                 Tensor kr_block = local_tile(k_restored_t, make_shape(Int<16>{}, Int<16>{}), make_coord(i, 0));
                 copy(smem_tiled_copy_A_T, smem_thr_copy_A_T.partition_S(kr_block), tCrAi_kr_view);
                 cute::transform(tCrAi_kr, ring_A_kr[i], cute::identity{});
-
-                #pragma unroll
-                for (int bi = 0; bi < 2; ++bi) {
-                    Tensor s_block = local_tile(s_acc_T, make_shape(Int<16>{}, Int<16>{}), make_coord(i, warp_id * 2 + bi));
-                    copy(smem_tiled_load_C_T, smem_thr_load_C_T.partition_S(s_block), smem_thr_load_C_T.retile_D(ring_S_acc[bi][i]));
-                }
 
                 ring_g0[i] = g_total(i * 16 + group_id);
                 ring_g1[i] = g_total(i * 16 + group_id + 8);
@@ -706,40 +689,42 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
 
                 #pragma unroll
                 for (int bi = 0; bi < 2; ++bi) {
+                    auto& state_fragment = resident_state[bi][m];
                     #pragma unroll
                     for (int a = 0; a < 2; ++a) {
                         #pragma unroll
                         for (int d = 0; d < 2; ++d) {
                             auto c0 = make_coord(make_coord(a, 0), 0, d);
                             auto c1 = make_coord(make_coord(a, 1), 0, d);
-                            ring_S_acc[bi][slot](c0) = BF16(bf16_to_f32(ring_S_acc[bi][slot](c0)) * g0 + u_acc[bi](c0));
-                            ring_S_acc[bi][slot](c1) = BF16(bf16_to_f32(ring_S_acc[bi][slot](c1)) * g1 + u_acc[bi](c1));
+                            state_fragment(c0) = BF16(bf16_to_f32(state_fragment(c0)) * g0 + u_acc[bi](c0));
+                            state_fragment(c1) = BF16(bf16_to_f32(state_fragment(c1)) * g1 + u_acc[bi](c1));
                         }
                     }
 
-                    Tensor s_block = local_tile(s_acc_T, make_shape(Int<16>{}, Int<16>{}), make_coord(m, warp_id * 2 + bi));
-                    copy(smem_tiled_store_C_T, smem_thr_store_C_T.retile_S(ring_S_acc[bi][slot]), smem_thr_store_C_T.partition_D(s_block));
-
-                    if (m + PREFETCH < S_M_BLOCKS) {
-                        Tensor s_next = local_tile(s_acc_T, make_shape(Int<16>{}, Int<16>{}), make_coord(m + PREFETCH, warp_id * 2 + bi));
-                        copy(smem_tiled_load_C_T, smem_thr_load_C_T.partition_S(s_next), smem_thr_load_C_T.retile_D(ring_S_acc[bi][slot]));
+                    // The store warp observes the last output-stage commit only
+                    // after these writes and the following shared-memory fence.
+                    if constexpr (HasStateOut) {
+                        if (t + 1 == t_tiles) {
+                            Tensor s_block = local_tile(
+                                s_acc_T,
+                                make_shape(Int<16>{}, Int<16>{}),
+                                make_coord(m, warp_id * 2 + bi));
+                            copy(smem_tiled_store_C_T, smem_thr_store_C_T.retile_S(state_fragment), smem_thr_store_C_T.partition_D(s_block));
+                        }
                     }
                 }
             }
             }
-            compute_barrier.arrive_and_wait();
-
-#ifndef TMA_DISABLE_ALL
+            // The collective commit releases this input stage and publishes
+            // both the output tile and an optional final-state spill.
             cutlass::arch::fence_view_async_shared();
             store_pipeline.producer_commit(out_write);
             load_pipeline.consumer_release(load_read);
             ++load_read;
             ++out_write;
-#endif
         }
     }
 
-#ifndef TMA_DISABLE_ALL
     if (warp_role == WarpRole::STORE && lane_predicate) {
         Tensor g_out = tma_store_out.get_tma_tensor(make_shape(H, T_total, D));
         auto cta_tma_store = tma_store_out.get_slice(Int<0>{});
@@ -831,5 +816,4 @@ __global__ void __launch_bounds__(NumThreads) _flash_kda_fwd_recurrence(
     }
 
     __syncthreads();
-#endif
 }

--- a/csrc/smxx/fwd_kernel2.cuh
+++ b/csrc/smxx/fwd_kernel2.cuh
@@ -824,5 +824,4 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
         }
     }
 
-    __syncthreads();
 }

--- a/csrc/smxx/fwd_kernel2.cuh
+++ b/csrc/smxx/fwd_kernel2.cuh
@@ -185,7 +185,8 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
         uint32_t(cute::cosize_v<LMLayout>) * uint32_t(sizeof(BF16)) * 2;
 
     // --- warp specialization
-    int warp_id = threadIdx.x / kWarpSize;
+    int warp_id = cutlass::canonical_warp_idx_sync();
+    bool lane_predicate = cute::elect_one_sync();
     WarpRole warp_role = WarpRole::NonParticipant;
     if (warp_id < kComputeThreads / kWarpSize) {
         warp_role = WarpRole::MMA;
@@ -193,6 +194,13 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
         warp_role = WarpRole::LOAD_QKG;
     } else if (warp_id < kComputeThreads / kWarpSize + 2) {
         warp_role = WarpRole::STORE;
+    }
+
+    if constexpr (HasStateIn) {
+        if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
+            shared_storage.state_acc_tma_barrier.init(1);
+            cutlass::arch::fence_barrier_init();
+        }
     }
 
     using LoadPipelineState = cutlass::PipelineState<InputStages>;
@@ -208,6 +216,9 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
         shared_storage.store_pipeline,
         warp_role, kComputeThreads, 1
     );
+    // Both pipeline constructors initialize shared barriers. One collective
+    // wait covers them and the optional state-load barrier above.
+    cutlass::pipeline_init_wait(1);
 
     // --- per-block sequence info
     int head_idx = int(blockIdx.x);
@@ -236,17 +247,13 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
     }
     int seq_len  = int(eos - bos);
     int t_tiles  = (seq_len + CHUNK - 1) / CHUNK;
-    bool lane_predicate = cute::elect_one_sync();
 
     // --- Load initial state
     if constexpr (HasStateIn && !StateFP32) {
         // BF16 state: TMA load directly into state_acc
-        if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
+        if (warp_role == WarpRole::LOAD_QKG) {
             using BarrierType = cutlass::arch::ClusterTransactionBarrier::ValueType;
             constexpr uint32_t kStateTransactionBytes = cute::cosize_v<StateSmemLayout> * sizeof(BF16);
-
-            shared_storage.state_acc_tma_barrier.init(1);
-            shared_storage.state_acc_tma_barrier.arrive_and_expect_tx(kStateTransactionBytes);
 
             Tensor g_init = tma_load_initial_state.get_tma_tensor(make_shape(N * H, D, D));
             auto init_off = g_init.layout()(seq_idx * H + head_idx, 0, 0);
@@ -255,26 +262,26 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
             Tensor s_state = make_tensor(make_smem_ptr(shared_storage.state_acc.begin()), TMAStateSmemLayout{});
 
             auto cta_tma_load_state = tma_load_initial_state.get_slice(Int<0>{});
-            cute::copy(
-                tma_load_initial_state.with(reinterpret_cast<BarrierType&>(shared_storage.state_acc_tma_barrier)),
-                cta_tma_load_state.partition_S(g_init_tile),
-                cta_tma_load_state.partition_D(s_state)
-            );
+            if (cute::elect_one_sync()) {
+                shared_storage.state_acc_tma_barrier.arrive_and_expect_tx(kStateTransactionBytes);
+                cute::copy(
+                    tma_load_initial_state.with(reinterpret_cast<BarrierType&>(shared_storage.state_acc_tma_barrier)),
+                    cta_tma_load_state.partition_S(g_init_tile),
+                    cta_tma_load_state.partition_D(s_state)
+                );
+            }
+            shared_storage.state_acc_tma_barrier.wait(0);
         }
         __syncthreads();
-        shared_storage.state_acc_tma_barrier.wait(0);
         cutlass::arch::fence_view_async_shared();
     } else if constexpr (HasStateIn && StateFP32) {
         // FP32 state: TMA load fp32 into pipeline buffer, then convert to bf16 in state_acc
         using FP32StateSmemLayout = typename Layouts::FP32StateSmemLayout;
         using TMAFP32StateSmemLayout = typename Layouts::TMAFP32StateSmemLayout;
 
-        if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
+        if (warp_role == WarpRole::LOAD_QKG) {
             using BarrierType = cutlass::arch::ClusterTransactionBarrier::ValueType;
             constexpr uint32_t kFP32StateTransactionBytes = cute::cosize_v<StateSmemLayout> * sizeof(float);
-
-            shared_storage.state_acc_tma_barrier.init(1);
-            shared_storage.state_acc_tma_barrier.arrive_and_expect_tx(kFP32StateTransactionBytes);
 
             Tensor g_init = tma_load_initial_state.get_tma_tensor(make_shape(N * H, D, D));
             auto init_off = g_init.layout()(seq_idx * H + head_idx, 0, 0);
@@ -285,14 +292,17 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
                 TMAFP32StateSmemLayout{});
 
             auto cta_tma_load_state = tma_load_initial_state.get_slice(Int<0>{});
-            cute::copy(
-                tma_load_initial_state.with(reinterpret_cast<BarrierType&>(shared_storage.state_acc_tma_barrier)),
-                cta_tma_load_state.partition_S(g_init_tile),
-                cta_tma_load_state.partition_D(s_fp32)
-            );
+            if (cute::elect_one_sync()) {
+                shared_storage.state_acc_tma_barrier.arrive_and_expect_tx(kFP32StateTransactionBytes);
+                cute::copy(
+                    tma_load_initial_state.with(reinterpret_cast<BarrierType&>(shared_storage.state_acc_tma_barrier)),
+                    cta_tma_load_state.partition_S(g_init_tile),
+                    cta_tma_load_state.partition_D(s_fp32)
+                );
+            }
+            shared_storage.state_acc_tma_barrier.wait(0);
         }
         __syncthreads();
-        shared_storage.state_acc_tma_barrier.wait(0);
         cutlass::arch::fence_view_async_shared();
 
         // All threads: convert fp32 -> bf16 with layout transformation
@@ -312,7 +322,6 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
         }
         __syncthreads();
     }
-    __syncthreads();
 
     // --- LOAD warp: issue TMA loads for v, beta, and workspace intermediates
     if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {

--- a/csrc/smxx/fwd_launch.cu
+++ b/csrc/smxx/fwd_launch.cu
@@ -1,3 +1,5 @@
+#include <type_traits>
+
 #include "fwd.h"
 #include "fwd_kernel1.cuh"
 #include "fwd_kernel2.cuh"
@@ -40,15 +42,23 @@ void launch_fwd(
     using K2L = K2Layouts<D, CHUNK>;
     using WS = WorkspaceSizes<CHUNK, D>;
 
+    // Raw bulk copies make the swizzled shared-memory layout a private ABI
+    // between K1 and K2. Fail at compile time if either side changes alone.
+    static_assert(std::is_same_v<typename K1L::MMALayout,
+                                 typename K2L::MMALayout>);
+    static_assert(std::is_same_v<typename K1L::GTotalLayout,
+                                 typename K2L::GTotalLayout>);
+    static_assert(std::is_same_v<typename K1L::LMLayout,
+                                 typename K2L::LMLayout>);
+
     // TMA layouts for Kernel 1
     using TMAQKLayout = typename K1L::TMAQKLayout;
     using TMAGLayout = typename K1L::TMAGLayout;
     using TMABetaSmemLayout = typename K1L::TMABetaSmemLayout;
-    using TMAVOLayout = typename K1L::TMAVOLayout;
-    using TMALMLayout = typename K1L::TMALMLayout;
     using TMAGTotalSmemLayout = typename K1L::TMAGTotalSmemLayout;
 
     // TMA layouts for Kernel 2
+    using TMAVOLayout = typename K2L::TMAVOLayout;
     using TMAStateSmemLayout = typename K2L::TMAStateSmemLayout;
     using TMAFP32StateSmemLayout = typename K2L::TMAFP32StateSmemLayout;
 
@@ -74,20 +84,7 @@ void launch_fwd(
     BF16*  ws_inv = reinterpret_cast<BF16*>(ws + n_ht * (WS::kKDecayed + WS::kQDecayed + WS::kKRestored + WS::kGTotal));
     BF16*  ws_mqk = reinterpret_cast<BF16*>(ws + n_ht * (WS::kKDecayed + WS::kQDecayed + WS::kKRestored + WS::kGTotal + WS::kINV));
 
-    auto ws_kd_gmem_layout = make_layout(make_shape(int(n_ht), CHUNK, D), LayoutRight{});
-    auto ws_qd_gmem_layout = ws_kd_gmem_layout;
-    auto ws_kr_gmem_layout = ws_kd_gmem_layout;
-    auto ws_gt_gmem_layout = make_layout(make_shape(int(n_ht), D), LayoutRight{});
-    auto ws_lm_gmem_layout = make_layout(make_shape(int(n_ht), CHUNK, CHUNK), LayoutRight{});
-
-    Tensor m_ws_kd  = make_tensor(make_gmem_ptr(ws_kd), ws_kd_gmem_layout);
-    Tensor m_ws_qd  = make_tensor(make_gmem_ptr(ws_qd), ws_qd_gmem_layout);
-    Tensor m_ws_kr  = make_tensor(make_gmem_ptr(ws_kr), ws_kr_gmem_layout);
-    Tensor m_ws_gt  = make_tensor(make_gmem_ptr(ws_gt), ws_gt_gmem_layout);
-    Tensor m_ws_inv = make_tensor(make_gmem_ptr(ws_inv), ws_lm_gmem_layout);
-    Tensor m_ws_mqk = make_tensor(make_gmem_ptr(ws_mqk), ws_lm_gmem_layout);
-
-    // --- TMA descriptors for Kernel 1 (loads: q,k,beta; stores: workspace)
+    // --- TMA descriptors for Kernel 1 inputs
     auto tma_load_q    = make_tma_copy(SM90_TMA_LOAD{}, m_q, TMAQKLayout{});
     auto tma_load_k    = make_tma_copy(SM90_TMA_LOAD{}, m_k, TMAQKLayout{});
     auto tma_load_beta = make_tma_copy(SM90_TMA_LOAD{}, m_beta, TMABetaSmemLayout{});
@@ -99,24 +96,10 @@ void launch_fwd(
     Tensor m_dt_bias = make_tensor(make_gmem_ptr(dt_bias_ptr), dt_bias_gmem_layout);
     auto tma_load_dt_bias = make_tma_copy(SM90_TMA_LOAD{}, m_dt_bias, TMAGTotalSmemLayout{});
 
-    auto tma_store_ws_kd  = make_tma_copy(SM90_TMA_STORE{}, m_ws_kd, TMAVOLayout{});
-    auto tma_store_ws_qd  = make_tma_copy(SM90_TMA_STORE{}, m_ws_qd, TMAVOLayout{});
-    auto tma_store_ws_kr  = make_tma_copy(SM90_TMA_STORE{}, m_ws_kr, TMAVOLayout{});
-    auto tma_store_ws_gt  = make_tma_copy(SM90_TMA_STORE{}, m_ws_gt, TMAGTotalSmemLayout{});
-    auto tma_store_ws_inv = make_tma_copy(SM90_TMA_STORE{}, m_ws_inv, TMALMLayout{});
-    auto tma_store_ws_mqk = make_tma_copy(SM90_TMA_STORE{}, m_ws_mqk, TMALMLayout{});
-
-    // --- TMA descriptors for Kernel 2 (loads: v,beta,workspace; load/store: state,out)
+    // --- TMA descriptors for Kernel 2 inputs and outputs. Workspace payloads
+    // use the raw bulk-copy pointers above rather than tensor maps.
     auto tma_load_v     = make_tma_copy(SM90_TMA_LOAD{}, m_v, TMAVOLayout{});
     auto tma_load_beta2 = make_tma_copy(SM90_TMA_LOAD{}, m_beta, TMABetaSmemLayout{});
-
-    auto tma_load_ws_kd  = make_tma_copy(SM90_TMA_LOAD{}, m_ws_kd, TMAVOLayout{});
-    auto tma_load_ws_qd  = make_tma_copy(SM90_TMA_LOAD{}, m_ws_qd, TMAVOLayout{});
-    auto tma_load_ws_kr  = make_tma_copy(SM90_TMA_LOAD{}, m_ws_kr, TMAVOLayout{});
-    auto tma_load_ws_gt  = make_tma_copy(SM90_TMA_LOAD{}, m_ws_gt, TMAGTotalSmemLayout{});
-    auto tma_load_ws_inv = make_tma_copy(SM90_TMA_LOAD{}, m_ws_inv, TMALMLayout{});
-    auto tma_load_ws_mqk = make_tma_copy(SM90_TMA_LOAD{}, m_ws_mqk, TMALMLayout{});
-
     auto tma_store_out = make_tma_copy(SM90_TMA_STORE{}, m_out, TMAVOLayout{});
 
     // --- State TMA descriptors (conditional on HasStateIn/HasStateOut and StateFP32)
@@ -150,7 +133,7 @@ void launch_fwd(
     // ===== Launch Kernel 1 (prepare) =====
 #if BLOCK_LEVEL_K1 >= 0
     {
-        constexpr int kK1Threads = 256;
+        constexpr int kK1Threads = 128;
         using SharedStorageK1T = SharedStorageK1<K1L>;
         int smem_size_k1 = sizeof(SharedStorageK1T);
 
@@ -158,8 +141,6 @@ void launch_fwd(
             decltype(tma_load_q), decltype(tma_load_k),
             decltype(tma_load_beta),
             decltype(tma_load_g), decltype(tma_load_dt_bias),
-            decltype(tma_store_ws_kd), decltype(tma_store_ws_qd), decltype(tma_store_ws_kr),
-            decltype(tma_store_ws_gt), decltype(tma_store_ws_inv), decltype(tma_store_ws_mqk),
             CHUNK, D, kK1Threads, IsVarlen, SeqlenT
         >;
 
@@ -171,10 +152,9 @@ void launch_fwd(
         kernel1<<<grid_k1, block_k1, smem_size_k1, stream>>>(
             tma_load_q, tma_load_k, tma_load_beta,
             tma_load_g, tma_load_dt_bias,
-            tma_store_ws_kd, tma_store_ws_qd, tma_store_ws_kr,
-            tma_store_ws_gt, tma_store_ws_inv, tma_store_ws_mqk,
             scale, T_total, H, N, cu_seqlens_ptr, total_tiles,
-            A_log_ptr, gate_scale
+            A_log_ptr, gate_scale,
+            ws_kd, ws_qd, ws_kr, ws_gt, ws_inv, ws_mqk
         );
     }
 #endif
@@ -188,8 +168,6 @@ void launch_fwd(
 
         auto kernel2 = _flash_kda_fwd_recurrence<
             decltype(tma_load_v), decltype(tma_load_beta2),
-            decltype(tma_load_ws_kd), decltype(tma_load_ws_qd), decltype(tma_load_ws_kr),
-            decltype(tma_load_ws_gt), decltype(tma_load_ws_inv), decltype(tma_load_ws_mqk),
             decltype(tma_load_initial_state),
             decltype(tma_store_final_state),
             decltype(tma_store_out),
@@ -199,17 +177,18 @@ void launch_fwd(
 
         cudaFuncSetAttribute(kernel2, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_k2);
 
-        dim3 grid_k2(N, H);
+        // K2 maps x to head so all heads of a sequence launch together.
+        // Varlen reverses y in-kernel to process vLLM's trailing prefills first.
+        dim3 grid_k2(H, N);
         dim3 block_k2(kK2Threads);
 
         kernel2<<<grid_k2, block_k2, smem_size_k2, stream>>>(
             tma_load_v, tma_load_beta2,
-            tma_load_ws_kd, tma_load_ws_qd, tma_load_ws_kr,
-            tma_load_ws_gt, tma_load_ws_inv, tma_load_ws_mqk,
             tma_load_initial_state,
             tma_store_final_state,
             tma_store_out,
-            out_ptr, T_total, H, N, cu_seqlens_ptr, total_tiles
+            out_ptr, T_total, H, N, cu_seqlens_ptr, total_tiles,
+            ws_kd, ws_qd, ws_kr, ws_gt, ws_inv, ws_mqk
         );
     }
 #endif

--- a/csrc/smxx/utils.cuh
+++ b/csrc/smxx/utils.cuh
@@ -111,7 +111,6 @@ cutlass::PipelineTmaAsync<Stages> make_load_pipeline(
     params.num_producers = num_producers;
 
     Pipeline pipeline(storage, params, Shape<_1,_1>{});
-    cutlass::pipeline_init_wait(1);
     return pipeline;
 }
 
@@ -138,7 +137,6 @@ cutlass::PipelineAsync<Stages> make_store_pipeline(
     params.consumer_arv_count = num_consumers;
 
     Pipeline pipeline(storage, params);
-    cutlass::pipeline_init_wait(1);
     return pipeline;
 }
 
@@ -378,4 +376,3 @@ __device__ void smem_cvt_bf16_to_fp32(
         fp32_view(r1, c1) = bf16_to_f32(bf16_view(r1, c1));
     }
 }
-


### PR DESCRIPTION
## Summary

This PR ports the core forward-kernel optimizations from [Flash-Flash-KDA](https://github.com/Itssshikhar/Flash-Flash-KDA) and adapts them to FlashKDA's existing API and vLLM workloads.

## Main changes from Flash-Flash-KDA

### Kernel 1: preparation

- Replace fragmented TensorMap workspace stores with raw bulk copies. Kernel 2 restores the byte-identical swizzled shared-memory representation, avoiding hundreds of small TMA segments per CTA.
- Reduce threadblock size from 256 to 128 threads to improve occupancy.
- Compute Q/K normalization factors separately and apply normalization while forming the decayed values in registers.
- Stage activated beta values, Q/K inverse norms, and `exp(A_log)` in shared memory.

### Kernel 2: recurrence

- Keep each MMA warp's recurrent-state fragments in registers across the chunk loop -> eliminate repeated shared memory loads/stores.
- Consume Kernel 1 workspace intermediates using raw bulk loads.

## Microbenchmarks

Configuration:

- NVIDIA GB300
- Baseline: `dev@fa7eb89`, Optimized: `0f38104`
- BF16 inputs, FP32 initial/final state. `D=128`, 8192 total tokens
- FlashInfer CUPTI timing, CUDA graphs enabled, Cold L2 cache. Alternating baseline/optimized measurement order

### Pure prefill: complete forward call

| Heads | Layout | Baseline | Optimized | Speedup |
|---:|---:|---:|---:|---:|
| 12 | 1 × 8192 | 673.01 µs | 542.58 µs | 1.240× |
| 12 | 2 × 4096 | 363.65 µs | 296.11 µs | 1.228× |
| 12 | 4 × 2048 | 209.41 µs | 173.47 µs | 1.207× |
| 96 | 1 × 8192 | 894.23 µs | 745.47 µs | 1.200× |
| 96 | 2 × 4096 | 747.97 µs | 653.20 µs | 1.145× |
| 96 | 4 × 2048 | 677.84 µs | 585.30 µs | 1.158× |

### Mixed decode + prefill: complete forward call

Decode sequences are one token each and precede a single prefill, matching vLLM's packed-request order. Every case contains 8192 total tokens.

| Heads | Workload | Baseline | Optimized | Speedup |
|---:|---:|---:|---:|---:|
| 12 | 7 decode + 8185 prefill | 679.39 µs | 551.79 µs | 1.231× |
| 12 | 15 decode + 8177 prefill | 682.85 µs | 555.25 µs | 1.230× |
| 12 | 31 decode + 8161 prefill | 704.72 µs | 561.81 µs | 1.254× |
| 96 | 7 decode + 8185 prefill | 1287.73 µs | 782.58 µs | 1.646× |
| 96 | 15 decode + 8177 prefill | 1361.37 µs | 809.17 µs | 1.682× |
| 96 | 31 decode + 8161 prefill | 1529.19 µs | 851.44 µs | 1.796× |

The mixed-batch comparison produced 0.000% relative RMSE for both output and final state against the baseline.

### Isolated kernel results

Across `1×8192`, `2×4096`, and `4×2048` pure-prefill layouts:

- Kernel 1 is 2.18–3.40% faster.
- Kernel 2 is 5.02–8.94% faster.