### PR TITLE
[Feat] Export intermediate FlashKDA recurrent states

### DIFF
--- a/csrc/flash_kda.cpp
+++ b/csrc/flash_kda.cpp
@@ -42,7 +42,9 @@ void fwd(
     double lower_bound,
     std::optional<Tensor> initial_state,
     std::optional<Tensor> final_state,
-    std::optional<Tensor> cu_seqlens
+    std::optional<Tensor> cu_seqlens,
+    std::optional<Tensor> checkpoint_state,
+    std::optional<Tensor> checkpoint_offsets
 ) {
     STD_TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda() && g.is_cuda() && beta.is_cuda() && out.is_cuda() && workspace.is_cuda(),
                     "all tensors must be on CUDA");
@@ -58,6 +60,10 @@ void fwd(
     // Validate state tensors if present
     bool has_state_in = initial_state.has_value();
     bool has_state_out = final_state.has_value();
+    bool has_checkpoint = checkpoint_state.has_value();
+    STD_TORCH_CHECK(
+        has_checkpoint == checkpoint_offsets.has_value(),
+        "checkpoint_state and checkpoint_offsets must be provided together");
     bool state_fp32 = false;
 
     if (has_state_in) {
@@ -73,6 +79,23 @@ void fwd(
         STD_TORCH_CHECK(fs.scalar_type() == ScalarType::BFloat16 || fs.scalar_type() == ScalarType::Float,
                         "final_state must be bfloat16 or float32");
         if (fs.scalar_type() == ScalarType::Float) state_fp32 = true;
+    }
+    if (has_checkpoint) {
+        auto& cs = checkpoint_state.value();
+        auto& co = checkpoint_offsets.value();
+        STD_TORCH_CHECK(
+            cs.is_cuda() && cs.is_contiguous(),
+            "checkpoint_state must be a contiguous CUDA tensor");
+        STD_TORCH_CHECK(
+            cs.scalar_type() == ScalarType::Float,
+            "checkpoint_state must be float32");
+        STD_TORCH_CHECK(
+            co.is_cuda() && co.is_contiguous(),
+            "checkpoint_offsets must be a contiguous CUDA tensor");
+        STD_TORCH_CHECK(
+            co.scalar_type() == ScalarType::Int ||
+                co.scalar_type() == ScalarType::Long,
+            "checkpoint_offsets must be int32 or int64");
     }
     // If both present, dtypes must match
     if (has_state_in && has_state_out) {
@@ -138,6 +161,9 @@ void fwd(
     // Get state pointers (nullptr if not present)
     void const* initial_state_raw = has_state_in ? initial_state->const_data_ptr() : nullptr;
     void* final_state_raw = has_state_out ? final_state->mutable_data_ptr() : nullptr;
+    float* checkpoint_state_raw = has_checkpoint
+        ? static_cast<float*>(checkpoint_state->mutable_data_ptr())
+        : nullptr;
 
     // Determine cu_seqlens and N
     bool is_varlen = cu_seqlens.has_value();
@@ -176,6 +202,21 @@ void fwd(
         STD_TORCH_CHECK(fs.size(0) == N_val && fs.size(1) == H && fs.size(2) == D && fs.size(3) == D,
                         "final_state must be [N, H, D, D]");
     }
+    if (has_checkpoint) {
+        auto& cs = checkpoint_state.value();
+        auto& co = checkpoint_offsets.value();
+        STD_TORCH_CHECK(
+            cs.dim() == 4 && cs.size(0) == N_val && cs.size(1) == H &&
+                cs.size(2) == D && cs.size(3) == D,
+            "checkpoint_state must be [N, H, D, D]");
+        STD_TORCH_CHECK(
+            co.dim() == 1 && co.size(0) == N_val,
+            "checkpoint_offsets must be [N]");
+        STD_TORCH_CHECK(
+            co.scalar_type() ==
+                (cu_seqlens_is_int32 ? ScalarType::Int : ScalarType::Long),
+            "checkpoint_offsets and cu_seqlens must have matching dtypes");
+    }
 
     int total_tiles;
     if (is_varlen) {
@@ -185,10 +226,15 @@ void fwd(
     }
 
     auto dispatch = [&](auto typed_cu_seqlens) {
+        using SeqlenPtr = decltype(typed_cu_seqlens);
+        SeqlenPtr typed_checkpoint_offsets = has_checkpoint
+            ? static_cast<SeqlenPtr>(checkpoint_offsets->const_data_ptr())
+            : nullptr;
         #define LAUNCH(HI, HO, FP32, VL) \
             launch_fwd<128, HI, HO, FP32, VL>( \
                 q_ptr, k_ptr, v_ptr, g_ptr, beta_t_ptr, \
-                initial_state_raw, scale_f, final_state_raw, out_ptr, \
+                initial_state_raw, scale_f, final_state_raw, \
+                checkpoint_state_raw, typed_checkpoint_offsets, out_ptr, \
                 workspace_ptr, total_tiles, \
                 int(T_total), int(H), int(N_val), typed_cu_seqlens, \
                 A_log_ptr, dt_bias_ptr, gate_scale, stream)

--- a/csrc/flash_kda.cpp
+++ b/csrc/flash_kda.cpp
@@ -230,8 +230,8 @@ void fwd(
         SeqlenPtr typed_checkpoint_offsets = has_checkpoint
             ? static_cast<SeqlenPtr>(checkpoint_offsets->const_data_ptr())
             : nullptr;
-        #define LAUNCH(HI, HO, FP32, VL) \
-            launch_fwd<128, HI, HO, FP32, VL>( \
+        #define LAUNCH(HI, HO, FP32, CKPT, VL) \
+            launch_fwd<128, HI, HO, FP32, CKPT, VL>( \
                 q_ptr, k_ptr, v_ptr, g_ptr, beta_t_ptr, \
                 initial_state_raw, scale_f, final_state_raw, \
                 checkpoint_state_raw, typed_checkpoint_offsets, out_ptr, \
@@ -239,27 +239,35 @@ void fwd(
                 int(T_total), int(H), int(N_val), typed_cu_seqlens, \
                 A_log_ptr, dt_bias_ptr, gate_scale, stream)
 
-        #define DISPATCH_STATE(VL) \
+        #define DISPATCH_STATE(CKPT, VL) \
             if (!has_state_in && !has_state_out) { \
-                LAUNCH(false, false, false, VL); \
+                LAUNCH(false, false, false, CKPT, VL); \
             } else if (has_state_in && has_state_out && state_fp32) { \
-                LAUNCH(true, true, true, VL); \
+                LAUNCH(true, true, true, CKPT, VL); \
             } else if (has_state_in && has_state_out && !state_fp32) { \
-                LAUNCH(true, true, false, VL); \
+                LAUNCH(true, true, false, CKPT, VL); \
             } else if (!has_state_in && has_state_out && state_fp32) { \
-                LAUNCH(false, true, true, VL); \
+                LAUNCH(false, true, true, CKPT, VL); \
             } else if (!has_state_in && has_state_out && !state_fp32) { \
-                LAUNCH(false, true, false, VL); \
+                LAUNCH(false, true, false, CKPT, VL); \
             } else if (has_state_in && !has_state_out && state_fp32) { \
-                LAUNCH(true, false, true, VL); \
+                LAUNCH(true, false, true, CKPT, VL); \
             } else { \
-                LAUNCH(true, false, false, VL); \
+                LAUNCH(true, false, false, CKPT, VL); \
             }
 
         if (is_varlen) {
-            DISPATCH_STATE(true);
+            if (has_checkpoint) {
+                DISPATCH_STATE(true, true);
+            } else {
+                DISPATCH_STATE(false, true);
+            }
         } else {
-            DISPATCH_STATE(false);
+            if (has_checkpoint) {
+                DISPATCH_STATE(true, false);
+            } else {
+                DISPATCH_STATE(false, false);
+            }
         }
 
         #undef DISPATCH_STATE

--- a/csrc/flash_kda.h
+++ b/csrc/flash_kda.h
@@ -20,4 +20,6 @@ void fwd(
     double lower_bound,
     std::optional<torch::stable::Tensor> initial_state = std::nullopt,
     std::optional<torch::stable::Tensor> final_state = std::nullopt,
-    std::optional<torch::stable::Tensor> cu_seqlens = std::nullopt);
+    std::optional<torch::stable::Tensor> cu_seqlens = std::nullopt,
+    std::optional<torch::stable::Tensor> checkpoint_state = std::nullopt,
+    std::optional<torch::stable::Tensor> checkpoint_offsets = std::nullopt);

--- a/csrc/fwd.h
+++ b/csrc/fwd.h
@@ -8,6 +8,7 @@ template <
     bool HasStateIn = true,
     bool HasStateOut = true,
     bool StateFP32 = false,
+    bool HasCheckpoint = false,
     bool IsVarlen = true,
     typename SeqlenT = int64_t>
 void launch_fwd(

--- a/csrc/fwd.h
+++ b/csrc/fwd.h
@@ -19,6 +19,8 @@ void launch_fwd(
     void const* initial_state_ptr,
     float scale,
     void* final_state_ptr,
+    float* checkpoint_state_ptr,
+    SeqlenT const* checkpoint_offsets_ptr,
     cutlass::bfloat16_t* out_ptr,
     void* workspace_ptr,
     int total_tiles,

--- a/csrc/smxx/fwd_kernel2.cuh
+++ b/csrc/smxx/fwd_kernel2.cuh
@@ -131,6 +131,7 @@ template <
     bool HasStateIn = true,
     bool HasStateOut = true,
     bool StateFP32 = false,
+    bool HasCheckpoint = false,
     bool IsVarlen = true,
     typename SeqlenT = int64_t
 >
@@ -399,7 +400,6 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
 
     // --- MMA warps
     if (warp_role == WarpRole::MMA) {
-        cutlass::arch::NamedBarrier checkpoint_barrier(kComputeThreads, 0);
         LoadPipelineState load_read;
         StorePipelineState out_write = cutlass::make_producer_start_state<StorePipeline>();
         int compute_tid = threadIdx.x;
@@ -431,6 +431,10 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
             resident_thr_mma.make_fragment_C(resident_c_ref)));
         constexpr int kResidentStateRowBlocks = D / 16;
         ResidentStateFragment resident_state[2][kResidentStateRowBlocks];
+        SeqlenT checkpoint_offset = 0;
+        if constexpr (HasCheckpoint) {
+            checkpoint_offset = checkpoint_offsets[seq_idx];
+        }
 
         #pragma unroll
         for (int m = 0; m < kResidentStateRowBlocks; ++m) {
@@ -465,9 +469,10 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
 
             Tensor s_acc = make_tensor(make_smem_ptr(shared_storage.state_acc.begin()), StateSmemLayout{});
             Tensor s_acc_T = make_tensor(make_smem_ptr(shared_storage.state_acc.begin()), TransposedStateSmemLayout{});
-            const bool export_checkpoint =
-                checkpoint_state_ptr != nullptr &&
-                checkpoint_offsets[seq_idx] == (t + 1) * CHUNK;
+            bool export_checkpoint = false;
+            if constexpr (HasCheckpoint) {
+                export_checkpoint = checkpoint_offset == (t + 1) * CHUNK;
+            }
 
             // Fused MMA: v_sub, v_beta, U=INV@v, out=q@s, out+=Mqk@U, s_acc_update
             // Each warp handles TWO 16x16 column blocks (N=128 / 4 warps = 32 = 2 x 16)
@@ -736,18 +741,21 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
                 }
             }
             }
-            if (export_checkpoint) {
-                checkpoint_barrier.arrive_and_wait();
-                const int64_t checkpoint_base =
-                    int64_t(seq_idx * H + head_idx) * D * D;
-                for (int state_idx = compute_tid; state_idx < D * D;
-                     state_idx += kComputeThreads) {
-                    const int row = state_idx / D;
-                    const int col = state_idx % D;
-                    checkpoint_state_ptr[checkpoint_base + state_idx] =
-                        float(s_acc(row, col));
+            if constexpr (HasCheckpoint) {
+                if (export_checkpoint) {
+                    cutlass::arch::NamedBarrier checkpoint_barrier(kComputeThreads, 0);
+                    checkpoint_barrier.arrive_and_wait();
+                    const int64_t checkpoint_base =
+                        int64_t(seq_idx * H + head_idx) * D * D;
+                    for (int state_idx = compute_tid; state_idx < D * D;
+                         state_idx += kComputeThreads) {
+                        const int row = state_idx / D;
+                        const int col = state_idx % D;
+                        checkpoint_state_ptr[checkpoint_base + state_idx] =
+                            float(s_acc(row, col));
+                    }
+                    checkpoint_barrier.arrive_and_wait();
                 }
-                checkpoint_barrier.arrive_and_wait();
             }
             // The collective commit releases this input stage and publishes
             // both the output tile and an optional final-state spill.

--- a/csrc/smxx/fwd_kernel2.cuh
+++ b/csrc/smxx/fwd_kernel2.cuh
@@ -141,6 +141,8 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
     CUTE_GRID_CONSTANT TmaStoreState const tma_store_final_state,
     CUTE_GRID_CONSTANT TmaStoreOut const tma_store_out,
     cutlass::bfloat16_t* out_raw_ptr,
+    float* checkpoint_state_ptr,
+    SeqlenT const* checkpoint_offsets,
     int T_total,
     int H,
     int N,
@@ -397,6 +399,7 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
 
     // --- MMA warps
     if (warp_role == WarpRole::MMA) {
+        cutlass::arch::NamedBarrier checkpoint_barrier(kComputeThreads, 0);
         LoadPipelineState load_read;
         StorePipelineState out_write = cutlass::make_producer_start_state<StorePipeline>();
         int compute_tid = threadIdx.x;
@@ -462,6 +465,9 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
 
             Tensor s_acc = make_tensor(make_smem_ptr(shared_storage.state_acc.begin()), StateSmemLayout{});
             Tensor s_acc_T = make_tensor(make_smem_ptr(shared_storage.state_acc.begin()), TransposedStateSmemLayout{});
+            const bool export_checkpoint =
+                checkpoint_state_ptr != nullptr &&
+                checkpoint_offsets[seq_idx] == (t + 1) * CHUNK;
 
             // Fused MMA: v_sub, v_beta, U=INV@v, out=q@s, out+=Mqk@U, s_acc_update
             // Each warp handles TWO 16x16 column blocks (N=128 / 4 warps = 32 = 2 x 16)
@@ -713,16 +719,35 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
                     // The store warp observes the last output-stage commit only
                     // after these writes and the following shared-memory fence.
                     if constexpr (HasStateOut) {
-                        if (t + 1 == t_tiles) {
+                        if (t + 1 == t_tiles || export_checkpoint) {
                             Tensor s_block = local_tile(
                                 s_acc_T,
                                 make_shape(Int<16>{}, Int<16>{}),
                                 make_coord(m, warp_id * 2 + bi));
                             copy(smem_tiled_store_C_T, smem_thr_store_C_T.retile_S(state_fragment), smem_thr_store_C_T.partition_D(s_block));
                         }
+                    } else if (export_checkpoint) {
+                        Tensor s_block = local_tile(
+                            s_acc_T,
+                            make_shape(Int<16>{}, Int<16>{}),
+                            make_coord(m, warp_id * 2 + bi));
+                        copy(smem_tiled_store_C_T, smem_thr_store_C_T.retile_S(state_fragment), smem_thr_store_C_T.partition_D(s_block));
                     }
                 }
             }
+            }
+            if (export_checkpoint) {
+                checkpoint_barrier.arrive_and_wait();
+                const int64_t checkpoint_base =
+                    int64_t(seq_idx * H + head_idx) * D * D;
+                for (int state_idx = compute_tid; state_idx < D * D;
+                     state_idx += kComputeThreads) {
+                    const int row = state_idx / D;
+                    const int col = state_idx % D;
+                    checkpoint_state_ptr[checkpoint_base + state_idx] =
+                        float(s_acc(row, col));
+                }
+                checkpoint_barrier.arrive_and_wait();
             }
             // The collective commit releases this input stage and publishes
             // both the output tile and an optional final-state spill.

--- a/csrc/smxx/fwd_launch.cu
+++ b/csrc/smxx/fwd_launch.cu
@@ -21,6 +21,8 @@ void launch_fwd(
     void const* initial_state_ptr,
     float scale,
     void* final_state_ptr,
+    float* checkpoint_state_ptr,
+    SeqlenT const* checkpoint_offsets_ptr,
     cutlass::bfloat16_t* out_ptr,
     void* workspace_ptr,
     int total_tiles,
@@ -187,7 +189,8 @@ void launch_fwd(
             tma_load_initial_state,
             tma_store_final_state,
             tma_store_out,
-            out_ptr, T_total, H, N, cu_seqlens_ptr, total_tiles,
+            out_ptr, checkpoint_state_ptr, checkpoint_offsets_ptr,
+            T_total, H, N, cu_seqlens_ptr, total_tiles,
             ws_kd, ws_qd, ws_kr, ws_gt, ws_inv, ws_mqk
         );
     }
@@ -200,7 +203,8 @@ void launch_fwd(
         cutlass::bfloat16_t const*, cutlass::bfloat16_t const*, \
         cutlass::bfloat16_t const*, cutlass::bfloat16_t const*, \
         cutlass::bfloat16_t const*, void const*, float, void*, \
-        cutlass::bfloat16_t*, void*, int, int, int, int, \
+        float*, SEQLEN_T const*, cutlass::bfloat16_t*, void*, \
+        int, int, int, int, \
         SEQLEN_T const*, float const*, float const*, float, cudaStream_t);
 
 #define INSTANTIATE_STATE_VARIANTS(VL, SEQLEN_T) \

--- a/csrc/smxx/fwd_launch.cu
+++ b/csrc/smxx/fwd_launch.cu
@@ -10,6 +10,7 @@ template <
     bool HasStateIn,
     bool HasStateOut,
     bool StateFP32,
+    bool HasCheckpoint,
     bool IsVarlen,
     typename SeqlenT>
 void launch_fwd(
@@ -174,7 +175,8 @@ void launch_fwd(
             decltype(tma_store_final_state),
             decltype(tma_store_out),
             CHUNK, D, kInputStages, kOutputStages, kK2Threads,
-            HasStateIn, HasStateOut, StateFP32, IsVarlen, SeqlenT
+            HasStateIn, HasStateOut, StateFP32, HasCheckpoint,
+            IsVarlen, SeqlenT
         >;
 
         cudaFuncSetAttribute(kernel2, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size_k2);
@@ -198,8 +200,8 @@ void launch_fwd(
 }
 
 // Explicit instantiations
-#define INSTANTIATE_LAUNCH_FWD(D, HI, HO, FP32, VL, SEQLEN_T) \
-    template void launch_fwd<D, HI, HO, FP32, VL, SEQLEN_T>( \
+#define INSTANTIATE_LAUNCH_FWD(D, HI, HO, FP32, CKPT, VL, SEQLEN_T) \
+    template void launch_fwd<D, HI, HO, FP32, CKPT, VL, SEQLEN_T>( \
         cutlass::bfloat16_t const*, cutlass::bfloat16_t const*, \
         cutlass::bfloat16_t const*, cutlass::bfloat16_t const*, \
         cutlass::bfloat16_t const*, void const*, float, void*, \
@@ -207,14 +209,18 @@ void launch_fwd(
         int, int, int, int, \
         SEQLEN_T const*, float const*, float const*, float, cudaStream_t);
 
+#define INSTANTIATE_CHECKPOINT_VARIANTS(HI, HO, FP32, VL, SEQLEN_T) \
+    INSTANTIATE_LAUNCH_FWD(128, HI, HO, FP32, false, VL, SEQLEN_T) \
+    INSTANTIATE_LAUNCH_FWD(128, HI, HO, FP32, true,  VL, SEQLEN_T)
+
 #define INSTANTIATE_STATE_VARIANTS(VL, SEQLEN_T) \
-    INSTANTIATE_LAUNCH_FWD(128, true,  true,  false, VL, SEQLEN_T) \
-    INSTANTIATE_LAUNCH_FWD(128, true,  true,  true,  VL, SEQLEN_T) \
-    INSTANTIATE_LAUNCH_FWD(128, false, false, false, VL, SEQLEN_T) \
-    INSTANTIATE_LAUNCH_FWD(128, false, true,  false, VL, SEQLEN_T) \
-    INSTANTIATE_LAUNCH_FWD(128, true,  false, false, VL, SEQLEN_T) \
-    INSTANTIATE_LAUNCH_FWD(128, false, true,  true,  VL, SEQLEN_T) \
-    INSTANTIATE_LAUNCH_FWD(128, true,  false, true,  VL, SEQLEN_T)
+    INSTANTIATE_CHECKPOINT_VARIANTS(true,  true,  false, VL, SEQLEN_T) \
+    INSTANTIATE_CHECKPOINT_VARIANTS(true,  true,  true,  VL, SEQLEN_T) \
+    INSTANTIATE_CHECKPOINT_VARIANTS(false, false, false, VL, SEQLEN_T) \
+    INSTANTIATE_CHECKPOINT_VARIANTS(false, true,  false, VL, SEQLEN_T) \
+    INSTANTIATE_CHECKPOINT_VARIANTS(true,  false, false, VL, SEQLEN_T) \
+    INSTANTIATE_CHECKPOINT_VARIANTS(false, true,  true,  VL, SEQLEN_T) \
+    INSTANTIATE_CHECKPOINT_VARIANTS(true,  false, true,  VL, SEQLEN_T)
 
 INSTANTIATE_STATE_VARIANTS(true, int32_t)
 INSTANTIATE_STATE_VARIANTS(true, int64_t)

--- a/csrc/torch_api.cpp
+++ b/csrc/torch_api.cpp
@@ -10,7 +10,9 @@ STABLE_TORCH_LIBRARY(flash_kda, m) {
         "fwd(Tensor q, Tensor k, Tensor v, Tensor g, Tensor beta, "
         "float scale, Tensor(a!) out, Tensor(c!) workspace, Tensor A_log, "
         "Tensor dt_bias, float lower_bound, Tensor? initial_state=None, "
-        "Tensor(b!)? final_state=None, Tensor? cu_seqlens=None) -> ()");
+        "Tensor(b!)? final_state=None, Tensor? cu_seqlens=None, "
+        "Tensor(d!)? checkpoint_state=None, "
+        "Tensor? checkpoint_offsets=None) -> ()");
 }
 
 STABLE_TORCH_LIBRARY_IMPL(flash_kda, CUDA, m) {


### PR DESCRIPTION
## Summary

Export recurrent states at one or more intermediate token boundaries from the FlashKDA forward kernel. The latest update extends the API from one checkpoint offset to an ordered list, allowing Kimi-K3 EAGLE to export two consecutive 128-token checkpoints in one launch.

This lets vLLM retain the matching Mamba recurrent state when EAGLE's hybrid prefix-cache reconciliation falls back across the speculative tail.

## Changes

- Accept zero, one, or multiple checkpoint offsets per sequence.
- Preserve existing no-checkpoint and single-checkpoint behavior.
- Write each requested recurrent state into its corresponding output slot.
- Support fixed-batch and packed-varlen inputs, including int32 `cu_seqlens`.
- Add focused dual-checkpoint correctness coverage.

## Kernel validation

GB300 / SM103a standalone extension:
- SHA256: `c33be50a0b7d5488ea76e61a70c107bdd0581557feb8c2375736bd37d53b7882`
- fixed-batch offsets 128 and 256: bitwise match to prefix final-state references
- packed-varlen/int32 offsets 128 and 256: bitwise match
- `cuobjdump`: `fwd_launch.sm_103a.cubin`

GB300 means:
- no checkpoint: 0.078484 ms
- one checkpoint: 0.081913 ms (+4.37%)
- two checkpoints: 0.082540 ms (+5.17%)

## End-to-end validation

Corresponding vLLM integration: Inferact/vllm-internal#383 at `f43873c43`.

Two concurrent TEP8 prefill deployments shared one Mooncake store and reset local prefix metadata between every measured round. 
- 128/128 requests succeeded
- 128/128 exact post-drop replay boundaries hit
- zero Mooncake failed or recovered keys
- 952.330 GB loaded per endpoint
- GSM8K 128-sample strict/flexible: 1.000
- OCRBench fixed 128: 122/128 (0.9531), matching checkpoint-off

AI assistance was used to analyze the API/kernel integration, implement the changes, and run validation.