### PR TITLE
[Kimi K3] Export two FlashKDA recurrent checkpoints

### DIFF
--- a/csrc/flash_kda.cpp
+++ b/csrc/flash_kda.cpp
@@ -213,16 +213,33 @@ void fwd(
         STD_TORCH_CHECK(fs.size(0) == N_val && fs.size(1) == H && fs.size(2) == D && fs.size(3) == D,
                         "final_state must be [N, H, D, D]");
     }
+    int64_t num_checkpoints = 1;
     if (has_checkpoint) {
         auto& cs = checkpoint_state.value();
         auto& co = checkpoint_offsets.value();
         STD_TORCH_CHECK(
-            cs.dim() == 4 && cs.size(0) == N_val && cs.size(1) == H &&
-                cs.size(2) == D && cs.size(3) == D,
-            "checkpoint_state must be [N, H, D, D]");
+            co.dim() == 1 || co.dim() == 2,
+            "checkpoint_offsets must be [N] or [N, K]");
+        num_checkpoints = co.dim() == 1 ? 1 : co.size(1);
         STD_TORCH_CHECK(
-            co.dim() == 1 && co.size(0) == N_val,
-            "checkpoint_offsets must be [N]");
+            num_checkpoints > 0 && num_checkpoints <= 2,
+            "checkpoint_offsets supports one or two checkpoints per sequence");
+        STD_TORCH_CHECK(
+            cs.dim() == co.dim() + 3 && cs.size(0) == N_val,
+            "checkpoint_state rank/prefix must match checkpoint_offsets");
+        STD_TORCH_CHECK(
+            co.size(0) == N_val,
+            "checkpoint_offsets first dimension must be N");
+        if (co.dim() == 2) {
+            STD_TORCH_CHECK(
+                cs.size(1) == num_checkpoints,
+                "checkpoint_state and checkpoint_offsets K must match");
+        }
+        int state_dim = int(cs.dim()) - 3;
+        STD_TORCH_CHECK(
+            cs.size(state_dim) == H && cs.size(state_dim + 1) == D &&
+                cs.size(state_dim + 2) == D,
+            "checkpoint_state suffix must be [H, D, D]");
         STD_TORCH_CHECK(
             co.scalar_type() ==
                 (cu_seqlens_is_int32 ? ScalarType::Int : ScalarType::Long),
@@ -245,7 +262,8 @@ void fwd(
             launch_fwd<128, HI, HO, FP32, CKPT, VL>( \
                 q_ptr, k_ptr, v_ptr, g_ptr, beta_t_ptr, \
                 initial_state_raw, scale_f, final_state_raw, \
-                checkpoint_state_raw, typed_checkpoint_offsets, out_ptr, \
+                checkpoint_state_raw, typed_checkpoint_offsets, \
+                int(num_checkpoints), out_ptr, \
                 workspace_ptr, total_tiles, \
                 int(T_total), int(H), int(N_val), typed_cu_seqlens, \
                 A_log_ptr, dt_bias_ptr, gate_scale, use_vsplit, stream)

--- a/csrc/fwd.h
+++ b/csrc/fwd.h
@@ -22,6 +22,7 @@ void launch_fwd(
     void* final_state_ptr,
     float* checkpoint_state_ptr,
     SeqlenT const* checkpoint_offsets_ptr,
+    int num_checkpoints,
     cutlass::bfloat16_t* out_ptr,
     void* workspace_ptr,
     int total_tiles,

--- a/csrc/smxx/fwd_kernel2.cuh
+++ b/csrc/smxx/fwd_kernel2.cuh
@@ -149,6 +149,7 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
     cutlass::bfloat16_t* out_raw_ptr,
     float* checkpoint_state_ptr,
     SeqlenT const* checkpoint_offsets,
+    int num_checkpoints,
     int T_total,
     int H,
     int N,
@@ -447,11 +448,6 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
             resident_thr_mma.make_fragment_C(resident_c_ref)));
         constexpr int kResidentStateRowBlocks = D / 16;
         ResidentStateFragment resident_state[kValueBlocksPerWarp][kResidentStateRowBlocks];
-        SeqlenT checkpoint_offset = 0;
-        if constexpr (HasCheckpoint) {
-            checkpoint_offset = checkpoint_offsets[seq_idx];
-        }
-
         #pragma unroll
         for (int m = 0; m < kResidentStateRowBlocks; ++m) {
             #pragma unroll
@@ -485,9 +481,17 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
 
             Tensor s_acc = make_tensor(make_smem_ptr(shared_storage.state_acc.begin()), StateSmemLayout{});
             Tensor s_acc_T = make_tensor(make_smem_ptr(shared_storage.state_acc.begin()), TransposedStateSmemLayout{});
+            int checkpoint_slot = -1;
             bool export_checkpoint = false;
             if constexpr (HasCheckpoint) {
-                export_checkpoint = checkpoint_offset == (t + 1) * CHUNK;
+                for (int slot = 0; slot < num_checkpoints; ++slot) {
+                    if (checkpoint_offsets[seq_idx * num_checkpoints + slot] ==
+                        (t + 1) * CHUNK) {
+                        checkpoint_slot = slot;
+                        break;
+                    }
+                }
+                export_checkpoint = checkpoint_slot >= 0;
             }
 
             // Fused MMA: v_sub, v_beta, U=INV@v, out=q@s, out+=Mqk@U, s_acc_update
@@ -769,7 +773,9 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
                     cutlass::arch::NamedBarrier checkpoint_barrier(kComputeThreads, 0);
                     checkpoint_barrier.arrive_and_wait();
                     const int64_t checkpoint_base =
-                        (int64_t(seq_idx * H + head_idx) * D +
+                        (int64_t(
+                             (seq_idx * num_checkpoints + checkpoint_slot) * H +
+                             head_idx) * D +
                          v_idx * VD) * D;
                     for (int state_idx = compute_tid; state_idx < VD * D;
                          state_idx += kComputeThreads) {

--- a/csrc/smxx/fwd_launch.cu
+++ b/csrc/smxx/fwd_launch.cu
@@ -24,6 +24,7 @@ void launch_fwd(
     void* final_state_ptr,
     float* checkpoint_state_ptr,
     SeqlenT const* checkpoint_offsets_ptr,
+    int num_checkpoints,
     cutlass::bfloat16_t* out_ptr,
     void* workspace_ptr,
     int total_tiles,
@@ -218,6 +219,7 @@ void launch_fwd(
                 tma_store_final_state_vsplit,
                 tma_store_out_vsplit,
                 out_ptr, checkpoint_state_ptr, checkpoint_offsets_ptr,
+                num_checkpoints,
                 T_total, H, N, cu_seqlens_ptr, total_tiles,
                 ws_kd, ws_qd, ws_kr, ws_gt, ws_inv, ws_mqk);
             return;
@@ -248,6 +250,7 @@ void launch_fwd(
             tma_store_final_state,
             tma_store_out,
             out_ptr, checkpoint_state_ptr, checkpoint_offsets_ptr,
+            num_checkpoints,
             T_total, H, N, cu_seqlens_ptr, total_tiles,
             ws_kd, ws_qd, ws_kr, ws_gt, ws_inv, ws_mqk
         );
@@ -261,7 +264,7 @@ void launch_fwd(
         cutlass::bfloat16_t const*, cutlass::bfloat16_t const*, \
         cutlass::bfloat16_t const*, cutlass::bfloat16_t const*, \
         cutlass::bfloat16_t const*, void const*, float, void*, \
-        float*, SEQLEN_T const*, cutlass::bfloat16_t*, void*, \
+        float*, SEQLEN_T const*, int, cutlass::bfloat16_t*, void*, \
         int, int, int, int, \
         SEQLEN_T const*, float const*, float const*, float, bool, \
         cudaStream_t);

--- a/tests/test_dual_checkpoint.py
+++ b/tests/test_dual_checkpoint.py
@@ -1,0 +1,138 @@
+import torch
+
+import flash_kda
+
+
+def _run_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor,
+    checkpoint_offsets: torch.Tensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    batch, tokens, heads, dim = q.shape
+    num_sequences = batch if cu_seqlens is None else cu_seqlens.numel() - 1
+    out = torch.empty_like(q)
+    final_state = torch.empty_like(initial_state)
+    checkpoint_state = None
+    if checkpoint_offsets is not None:
+        checkpoint_state = torch.empty(
+            (*checkpoint_offsets.shape, heads, dim, dim),
+            dtype=torch.float32,
+            device=q.device,
+        )
+    workspace = torch.empty(
+        flash_kda.get_workspace_size(batch * tokens, heads, num_sequences),
+        dtype=torch.uint8,
+        device=q.device,
+    )
+    torch.ops.flash_kda.fwd(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        dim**-0.5,
+        out,
+        workspace,
+        torch.zeros(heads, dtype=torch.float32, device=q.device),
+        torch.zeros(heads, dim, dtype=torch.float32, device=q.device),
+        -3.0,
+        initial_state,
+        final_state,
+        cu_seqlens,
+        checkpoint_state,
+        checkpoint_offsets,
+    )
+    return final_state, checkpoint_state
+
+
+@torch.inference_mode()
+def test_two_checkpoints_match_prefix_final_states():
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    batch, tokens, heads, dim = 1, 384, 8, 128
+    shape = (batch, tokens, heads, dim)
+    q, k, v, g = [
+        torch.randn(shape, dtype=torch.bfloat16, device=device) for _ in range(4)
+    ]
+    beta = torch.randn(
+        batch, tokens, heads, dtype=torch.bfloat16, device=device
+    )
+    initial_state = torch.randn(
+        batch, heads, dim, dim, dtype=torch.float32, device=device
+    )
+    offsets = torch.tensor([[128, 256]], dtype=torch.int64, device=device)
+
+    _, checkpoints = _run_fwd(q, k, v, g, beta, initial_state, offsets)
+    assert checkpoints is not None
+    for checkpoint_slot, offset in enumerate(offsets[0].tolist()):
+        reference, _ = _run_fwd(
+            q[:, :offset],
+            k[:, :offset],
+            v[:, :offset],
+            g[:, :offset],
+            beta[:, :offset],
+            initial_state,
+        )
+        torch.testing.assert_close(
+            checkpoints[:, checkpoint_slot], reference, rtol=0, atol=0
+        )
+
+
+@torch.inference_mode()
+def test_two_varlen_checkpoints_match_per_sequence_prefix_states():
+    """Exercise the exact packed-varlen, int32-offset path used by vLLM."""
+    torch.manual_seed(1)
+    device = torch.device("cuda")
+    lengths = [384, 320]
+    total_tokens, heads, dim = sum(lengths), 8, 128
+    shape = (1, total_tokens, heads, dim)
+    q, k, v, g = [
+        torch.randn(shape, dtype=torch.bfloat16, device=device) for _ in range(4)
+    ]
+    beta = torch.randn(
+        1, total_tokens, heads, dtype=torch.bfloat16, device=device
+    )
+    initial_state = torch.randn(
+        len(lengths), heads, dim, dim, dtype=torch.float32, device=device
+    )
+    cu_seqlens = torch.tensor(
+        [0, lengths[0], total_tokens], dtype=torch.int32, device=device
+    )
+    offsets = torch.tensor(
+        [[128, 256], [128, 256]], dtype=torch.int32, device=device
+    )
+
+    _, checkpoints = _run_fwd(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state,
+        offsets,
+        cu_seqlens,
+    )
+    assert checkpoints is not None
+    for sequence_idx, bos in enumerate(cu_seqlens[:-1]):
+        start = int(bos.item())
+        for checkpoint_slot, offset in enumerate(offsets[sequence_idx].tolist()):
+            stop = start + offset
+            reference, _ = _run_fwd(
+                q[:, start:stop],
+                k[:, start:stop],
+                v[:, start:stop],
+                g[:, start:stop],
+                beta[:, start:stop],
+                initial_state[sequence_idx : sequence_idx + 1],
+            )
+            torch.testing.assert_close(
+                checkpoints[sequence_idx, checkpoint_slot],
+                reference[0],
+                rtol=0,
+                atol=0,
+            )


### PR DESCRIPTION
## Summary

Stacked on #7. Extend FlashKDA checkpoint export from one recurrent state per sequence to up to two ordered checkpoint states, which vLLM uses for EAGLE prefix-cache fallback.

## Changes

- Accept checkpoint offsets shaped `[N, K]`, with `K <= 2`, while retaining the existing single-checkpoint behavior.
- Emit checkpoint states shaped `[N, K, H, D, D]`.
- Match each requested offset at a completed chunk boundary and write into its corresponding slot.
- Add fixed-batch and packed-varlen dual-checkpoint coverage.

## Validation

- Built a standalone vLLM-namespace extension for GB300 / SM103a with CUDA 13.
- `cuobjdump` confirms an `fwd_launch.sm_103a.cubin` image.
- Fixed-batch and packed-varlen/int32 checkpoints at offsets 128 and 256 match independent prefix final-state references bitwise.
- GB300 kernel means: no checkpoint 0.078484 ms; one checkpoint 0.081913 ms (+4.37%); two checkpoints 0.082540 ms (+5.17%).

The end-to-end EAGLE replay-hit and accuracy/performance A/B remains in progress, so this PR is opened as a draft.
